### PR TITLE
fix: rax-modal style bug, add display:flex to fix vertical center bug in web env

### DIFF
--- a/packages/rax-modal/src/index.css
+++ b/packages/rax-modal/src/index.css
@@ -6,6 +6,7 @@
   height: 3000rpx;
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 100;
+  display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;


### PR DESCRIPTION
use rax-scripts as follow:

`
{
  "inlineStyle": false,
  "plugins": [
    [
      "rax-plugin-app",
      {
        "targets": ["web"]
      }
    ]
  ]
}
`

the modal is not vertical center of the page, add display:flex can fix the bug