### PR TITLE
chore: check and publish automaticlly

### DIFF
--- a/.github/workflows/auto-publisher.yml
+++ b/.github/workflows/auto-publisher.yml
@@ -1,6 +1,10 @@
 name: Auto Publisher
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+      - 'releases/**'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/auto-publisher.yml
+++ b/.github/workflows/auto-publisher.yml
@@ -1,0 +1,17 @@
+name: Auto Publisher
+
+on: [push]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - run: npm i
+      - run: npm run check-and-publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@types/jest": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
+    "axios": "^0.19.0",
+    "semver": "^6.3.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
@@ -58,6 +60,7 @@
     "lint": "npm run lint:nofix -- --fix",
     "lint:nofix": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx ./",
     "test": "rax-scripts test",
+    "check-and-publish": "node ./scripts/check-and-publish",
     "clean:compile": "rm -rf ./packages/*/lib"
   },
   "config": {

--- a/packages/rax-empty/package.json
+++ b/packages/rax-empty/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "rax-empty",
-  "version": "0.0.1-0"
-}

--- a/packages/rax-empty/package.json
+++ b/packages/rax-empty/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "rax-empty",
+  "version": "0.0.1-0"
+}

--- a/scripts/check-and-publish.js
+++ b/scripts/check-and-publish.js
@@ -21,8 +21,8 @@ function checkVersion(folder, callback) {
     }
 
     for (let i = 0; i < packages.length; i++) {
-      const package = packages[i];
-      const packageInfoPath = join(folder, package, 'package.json');
+      const packageFolderName = packages[i];
+      const packageInfoPath = join(folder, packageFolderName, 'package.json');
       if (existsSync(packageInfoPath)) {
         const packageInfo = JSON.parse(readFileSync(packageInfoPath));
         getVersion(packageInfo.name)
@@ -30,7 +30,7 @@ function checkVersion(folder, callback) {
             if (version !== packageInfo.version) {
               ret.push({
                 name: packageInfo.name,
-                workDir: join(folder, package),
+                workDir: join(folder, packageFolderName),
                 latest: version,
                 local: packageInfo.version
               });
@@ -74,6 +74,10 @@ function isPrerelease(v) {
 
 function checkVersionAndPublish() {
   checkVersion(join(__dirname, 'packages'), (ret) => {
+    if (ret.length === 0) {
+      console.log('[PUBLISH] No diff with all packages.');
+    }
+
     for (let i = 0; i < ret.length; i++) {
       const { name, workDir, latest, local } = ret[i];
       const tag = isPrerelease(local) ? 'beta' : 'latest';

--- a/scripts/check-and-publish.js
+++ b/scripts/check-and-publish.js
@@ -54,7 +54,7 @@ function checkVersionExists(pkg, version) {
     .catch(err => false);
 }
 
-function publish(pkg, workDir, version, shouldBuild) {
+function publish(pkg, workDir, version, shouldBuild, tag) {
   console.log('[PUBLISH]', `${pkg}@${version}`);
 
   // npm install

--- a/scripts/check-and-publish.js
+++ b/scripts/check-and-publish.js
@@ -1,0 +1,85 @@
+/**
+ * Scripts to check unpublished version and run publish
+ */
+const { existsSync, readdirSync, readFileSync } = require('fs');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+const axios = require('axios');
+const semver = require('semver');
+
+function checkVersion(folder, callback) {
+  const ret = []; // { name: 'foo', workDir, latest: 'x.x.x', local: 'x.x.x'}
+  if (existsSync(folder)) {
+    const packages = readdirSync(folder);
+
+    let finishCount = 0;
+    function finish() {
+      finishCount++;
+      if (finishCount === packages.length) {
+        callback(ret);
+      }
+    }
+
+    for (let i = 0; i < packages.length; i++) {
+      const package = packages[i];
+      const packageInfoPath = join(folder, package, 'package.json');
+      if (existsSync(packageInfoPath)) {
+        const packageInfo = JSON.parse(readFileSync(packageInfoPath));
+        getVersion(packageInfo.name)
+          .then((version) => {
+            if (version !== packageInfo.version) {
+              ret.push({
+                name: packageInfo.name,
+                workDir: join(folder, package),
+                latest: version,
+                local: packageInfo.version
+              });
+            }
+            finish();
+          })
+          .catch((err) => {
+            console.log('Error: getting version of ' + packageInfoPath.name);
+            console.log(err);
+          })
+      }
+    }
+  } else {
+    callback(ret);
+  }
+}
+
+function getVersion(pkg, tag = 'latest') {
+  return axios(`http://registry.npmjs.com/${pkg}/${tag}`)
+    .then((res) => res.data.version);
+}
+
+function publish(pkg, workDir, version, tag = 'latest') {
+  console.log('[PUBLISH]', `${pkg}@${version} tag=${tag}`);
+
+  spawnSync('npm', [
+    'publish',
+    '--tag=' + tag,
+    // use default registry
+  ], {
+    stdio: 'inherit',
+    cwd: workDir,
+  });
+}
+
+function isPrerelease(v) {
+  const semVer = semver.parse(v);
+  if (semVer === null) return false;
+  return semVer.prerelease.length > 0;
+}
+
+function checkVersionAndPublish() {
+  checkVersion(join(__dirname, 'packages'), (ret) => {
+    for (let i = 0; i < ret.length; i++) {
+      const { name, workDir, latest, local } = ret[i];
+      const tag = isPrerelease(local) ? 'beta' : 'latest';
+      publish(name, workDir, local, tag);
+    }
+  });
+}
+
+checkVersionAndPublish();

--- a/scripts/check-and-publish.js
+++ b/scripts/check-and-publish.js
@@ -106,7 +106,7 @@ function checkVersionAndPublish() {
       const { name, workDir, local, shouldBuild } = ret[i];
       const tag = isPrerelease(local) ? 'beta' : 'latest';
       console.log(`--- ${name}@${local} current tag: ${tag} ---`);
-      // publish(name, workDir, local, shouldBuild, tag);
+      publish(name, workDir, local, shouldBuild, tag);
     }
   });
 }

--- a/scripts/check-and-publish.js
+++ b/scripts/check-and-publish.js
@@ -49,7 +49,7 @@ function checkVersion(folder, callback) {
 }
 
 function checkVersionExists(pkg, version) {
-  return axios(`http://registry.npmjs.com/${pkg}/${version}`, { timeout: 2000 })
+  return axios(`http://registry.npmjs.com/${encodeURIComponent(pkg)}/${encodeURIComponent(version)}`, { timeout: 2000 })
     .then((res) => res.status === 200)
     .catch(err => false);
 }


### PR DESCRIPTION
- 组件和 API 包发布权限收敛到发布机器人，杜绝人为干预发布过程，产生各种操作失误。
- 所有发布需要走 PR 和 Review 流程并合并到 Master 分支后自动触发，避免私下发布的问题。
- 脚本会对比本地版本与线上版本差异，并根据版本规则自动识别 beta/latest tag，然后构建发布到 npm。
