### PR TITLE
fix: rax-picture change source.uri can not update at weex

### DIFF
--- a/packages/rax-picture/src/pictureWeex.tsx
+++ b/packages/rax-picture/src/pictureWeex.tsx
@@ -66,7 +66,7 @@ function shouldComponentUpdate(preProps, nextProps) {
     return true;
   }
 
-  return preProps.source.uri !== nextProps.source.uri;
+  return preProps.source.uri === nextProps.source.uri;
 }
 
 export default memo(Picture, shouldComponentUpdate);


### PR DESCRIPTION
fix rax-picture component can't update at weex platform
cause for emergence: memo function second param error

about React.memo intro at react document 

> Note
> Unlike the shouldComponentUpdate() method on class components, the areEqual function returns true if the props are equal and false if the props are not equal. This is the inverse from shouldComponentUpdate.