### PR TITLE
fix: wechat miniprogram text render

### DIFF
--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-text",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-text",
-  "version": "1.1.7",
+  "version": "1.1.7-0",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-text/src/miniapp-wechat/index.ts
+++ b/packages/rax-text/src/miniapp-wechat/index.ts
@@ -13,6 +13,10 @@ Component({
     numberOfLines: {
       type: Number,
       value: 0
+    },
+    __content: {
+      type: String,
+      value: ''
     }
   },
   options: {

--- a/packages/rax-text/src/miniapp-wechat/index.ts
+++ b/packages/rax-text/src/miniapp-wechat/index.ts
@@ -1,7 +1,6 @@
 import fmtEvent from './fmtEvent';
 
 Component({
-  data: {},
   properties: {
     className: {
       type: String,

--- a/packages/rax-text/src/miniapp-wechat/index.wxml
+++ b/packages/rax-text/src/miniapp-wechat/index.wxml
@@ -1,5 +1,6 @@
-<view class="_rax-text {{className}} {{numberOfLines ? '_mutilple-lines' : ''}}"
-    style="-webkit-line-clamp: {{numberOfLines}};{{styleSheet}}"
+<!--wecaht numberOfLines should add 1-->
+<text class="_rax-text {{className}} {{numberOfLines ? '_mutilple-lines' : ''}}"
+    style="-webkit-line-clamp: {{numberOfLines + 1}};{{styleSheet}}"
     bindtap="onClick">
-  <slot></slot>
-</view>
+  {{__content}}
+</text>

--- a/packages/rax-text/src/miniapp-wechat/index.wxml
+++ b/packages/rax-text/src/miniapp-wechat/index.wxml
@@ -1,6 +1,5 @@
-<text class="{{className}}"
-    style="{{styleSheet}}"
-    number-of-lines="{{numberOfLines}}"
+<view class="_rax-text {{className}} {{numberOfLines ? '_mutilple-lines' : ''}}"
+    style="-webkit-line-clamp: {{numberOfLines}};{{styleSheet}}"
     bindtap="onClick">
-    <slot />
-</text>
+  <slot></slot>
+</view>

--- a/packages/rax-text/src/miniapp-wechat/index.wxss
+++ b/packages/rax-text/src/miniapp-wechat/index.wxss
@@ -1,0 +1,12 @@
+._rax-text {
+  display: inline;
+}
+
+._mutilple-lines {
+  overflow: hidden;
+  box-sizing: border-box;
+  display: -webkit-box;
+  word-break: break-all;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+}


### PR DESCRIPTION
1. 微信小程序的 text 组件里用 slot 会有渲染不及时的 bug
2. 修复微信小程序的多行属性其实根本没生效的问题