### PR TITLE
feat: rax-modal onClose

### DIFF
--- a/packages/rax-modal/src/index.tsx
+++ b/packages/rax-modal/src/index.tsx
@@ -20,6 +20,7 @@ function Modal(props: ModalProps) {
     maskCanBeClick = true,
     maskStyle = {},
     contentStyle = {},
+    onClose,
     onShow,
     onHide,
     children,
@@ -102,7 +103,7 @@ function Modal(props: ModalProps) {
       onTouchStart={preventDefault}
       onClick={e => {
         if (maskCanBeClick) {
-          onHide && onHide();
+          onClose && onClose();
         }
       }}
       ref={maskRef}

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -8,6 +8,7 @@ export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttribute
   contentStyle?: CSSProperties;
   delay?: number;
   duration?: number | [number] | [number, number]; // [number, number?] not work
+  onClose?: () => void;
   onShow?: () => void;
   onHide?: () => void;
 }


### PR DESCRIPTION
Modal 的 onShow onHide 表示的应该是 show 和 hide 的动画结束
但 maskCanBeClick 为 true 时点击 mask 会触发 onHide 感觉不是很合理(会触发两次 onHide)
所以加了一个属性 onClose，具体应该叫什么名字可以再讨论一下(感觉 onRequestClose 更合理一点)
参考:
ant-design onCancel https://ant.design/components/modal/
material-ui onClose https://material-ui.com/zh/api/modal/
react-native onRequestClose https://github.com/facebook/react-native/blob/master/Libraries/Modal/Modal.js#L104

使用方式就变成了:
```javascript

openModal = () => {
  this.setState({
    visible: true,
    renderContent: true,
  });
}

// ...

<Modal
  visible={this.state.visible}
  onClose={() => {
    // 受控模式下请求关闭 Modal
    // 此时 Modal 是可见的
    this.setState({
      visible: false,
    })
  }}
  onHide={() => {
    // hide 动画结束 Modal 已不可见
    this.setState({
      renderContent: false,
    });
  }}
>
  {this.state.renderContent && <ContentComponent />}
</Modal>
```