### PR TITLE
feat: use px in scaling

### DIFF
--- a/packages/rax-picture/package.json
+++ b/packages/rax-picture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-picture",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Picture component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-picture/src/optimizer/scaling.ts
+++ b/packages/rax-picture/src/optimizer/scaling.ts
@@ -62,9 +62,9 @@ export default function(sWidth: string | number, isOSSImg: any): string {
   let xWidth = 0;
   let scaling = 1;
   if (typeof sWidth === 'string') {
+    xWidth = parseFloat(sWidth);
     if (sWidth.indexOf('rpx') > -1) {
       // isRpx
-      xWidth = parseFloat(sWidth);
       if (width) {
         scaling = visualStandard / width;
       }


### PR DESCRIPTION
当图片宽度为 px 单位时，当前计算规则无法根据真实图片尺寸进行缩放，因为只计算了 rpx 的情况。
当图片单位为 rem vw 等单位时，在无法匹配适合最小宽度的情况下会走默认值与当前逻辑一致