### PR TITLE
fix: empty node in countdown

### DIFF
--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-countdown",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Countdown component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-countdown/src/index.js
+++ b/packages/rax-countdown/src/index.js
@@ -148,6 +148,8 @@ class Index extends Component {
     };
 
     let rule = new RegExp('\{[d,h,m,s]\}', 'g'); // used to matched all template item, which includes 'd', 'h', 'm' and 's'.
+
+    // Turn {d}-{h}-{m}-{s} to [0, 0, 4, 4, 8, 8, 12, 12, -1]
     const matchlist = [];
     let tmp = null;
     while ( (tmp = rule.exec(tpl)) !== null ) {
@@ -174,14 +176,12 @@ class Index extends Component {
             case 'h':
             case 'm':
             case 's':
-              if (index % 2 === 0) {// insert plain text before current matched item
-                return (
-                  <Text style={textStyle}>
-                    {
-                      tpl.slice(lastPlaintextIndex, val)
-                    }
-                  </Text>
-                );
+              if (index % 2 === 0) {
+                // Insert plain text before current matched item
+                // eg. in `{d}-{h}`:  text before `{d}` is ``, text before `{h}` is `-`
+                const preText = tpl.slice(lastPlaintextIndex, val);
+                // Do not generate text node if there is no preText
+                return preText ? <Text style={textStyle}>{preText}</Text> : null;
               } else {// replace current matched item to realtime string
                 lastPlaintextIndex = val + 3;
                 return addZero(timeType[matchedCharacter], timeWrapStyle, timeBackground, timeBackgroundStyle, timeStyle, secondStyle);


### PR DESCRIPTION
去除模板为 `{d}-{h}-{m}-{s}` 形式带来的空节点

![image](https://user-images.githubusercontent.com/1303018/75007945-98ef8500-54b1-11ea-81b0-e03b2e791ec6.png)
