### PR TITLE
fix: rax-modal types

### DIFF
--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "rax-modal",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -1,8 +1,8 @@
-import { RefAttributes, HTMLAttributes, CSSProperties, ComponentType } from 'rax';
+import { RefAttributes, HTMLAttributes, CSSProperties, RaxElement } from 'rax';
 
 export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttributes<HTMLDivElement> {
   visible: boolean;
-  children?: ComponentType[];
+  children?: RaxElement;
   maskCanBeClick?: boolean;
   maskStyle?: CSSProperties;
   contentStyle?: CSSProperties;


### PR DESCRIPTION
## 现象

* 测试代码：

```jsx
 <Modal>
   <div>foooooo</div>
 </Modal>
```
* 在 ts 环境下 children 类型报错
![image](https://user-images.githubusercontent.com/5419233/75607831-e1ecac80-5b35-11ea-8033-92946a80e783.png)

## Fix
Modal 的 children 之前定义为 ComponentType[]，有两个问题，一个是 Modal 的 children 为 element 类型而不是 component，第二个是 children 不一定是数组，参考 typescript 官网对于 [ React children type](https://www.typescriptlang.org/docs/handbook/jsx.html#children-type-checking) 的定义，将 Rax 中 children 定义为 RaxElement 类型