### PR TITLE
Fix rax picture scaling

### DIFF
--- a/packages/rax-picture/package.json
+++ b/packages/rax-picture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-picture",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Picture component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-picture/src/optimizer/scaling.ts
+++ b/packages/rax-picture/src/optimizer/scaling.ts
@@ -30,21 +30,21 @@ function find(c: number, arr: number[]) {
   let min = 1000;
   let result = c;
   let fKey = 0;
-  arr.forEach((num, key) => {
-    var abs = Math.abs(num - c);
-
+  let isAbsoluteValue = false;
+  for (let i = 0; i < arr.length; i++) {
+    const num = arr[i];
+    let abs = Math.abs(num - c);
     if (abs === 0) {
       result = num;
-      fKey = key;
-      return false;
+      fKey = i;
+      isAbsoluteValue = true;
     }
-
-    if (min > abs) {
+    if (min > abs && !isAbsoluteValue) {
       min = abs;
       result = num;
-      fKey = key;
+      fKey = i;
     }
-  });
+  }
   if (c > result && arr[fKey + 1]) {
     result = arr[fKey + 1];
   }

--- a/packages/rax-picture/src/optimizer/scaling.ts
+++ b/packages/rax-picture/src/optimizer/scaling.ts
@@ -30,16 +30,16 @@ function find(c: number, arr: number[]) {
   let min = 1000;
   let result = c;
   let fKey = 0;
-  let isAbsoluteValue = false;
+  let isMatchValue = false;
   for (let i = 0; i < arr.length; i++) {
     const num = arr[i];
     let abs = Math.abs(num - c);
     if (abs === 0) {
       result = num;
       fKey = i;
-      isAbsoluteValue = true;
+      isMatchValue = true;
     }
-    if (min > abs && !isAbsoluteValue) {
+    if (min > abs && !isMatchValue) {
       min = abs;
       result = num;
       fKey = i;

--- a/packages/rax-picture/src/optimizer/scaling.ts
+++ b/packages/rax-picture/src/optimizer/scaling.ts
@@ -30,20 +30,21 @@ function find(c: number, arr: number[]) {
   let min = 1000;
   let result = c;
   let fKey = 0;
-  for (let i = 0; i < arr.length; i++) {
-    const num = arr[i];
-    let abs = Math.abs(num - c);
+  arr.forEach((num, key) => {
+    var abs = Math.abs(num - c);
+
     if (abs === 0) {
       result = num;
-      fKey = i;
+      fKey = key;
       return false;
     }
+
     if (min > abs) {
       min = abs;
       result = num;
-      fKey = i;
+      fKey = key;
     }
-  }
+  });
   if (c > result && arr[fKey + 1]) {
     result = arr[fKey + 1];
   }

--- a/packages/rax-picture/src/optimizer/scaling.ts
+++ b/packages/rax-picture/src/optimizer/scaling.ts
@@ -26,14 +26,14 @@ const scalingWidth = [
 ];
 const visualStandard = 750;
 
-function find(c: number, arr: number[]) {
+function find(width: number) {
   let min = 1000;
-  let result = c;
+  let result = width;
   let fKey = 0;
   let isMatchValue = false;
-  for (let i = 0; i < arr.length; i++) {
-    const num = arr[i];
-    let abs = Math.abs(num - c);
+  for (let i = 0; i < scalingWidth.length; i++) {
+    const num = scalingWidth[i];
+    let abs = Math.abs(num - width);
     if (abs === 0) {
       result = num;
       fKey = i;
@@ -45,10 +45,10 @@ function find(c: number, arr: number[]) {
       fKey = i;
     }
   }
-  if (c > result && arr[fKey + 1]) {
-    result = arr[fKey + 1];
+  if (width > result && scalingWidth[fKey + 1]) {
+    result = scalingWidth[fKey + 1];
   }
-  if (arr.indexOf(result) > -1) {
+  if (scalingWidth.indexOf(result) > -1) {
     return result;
   }
   return false;
@@ -74,6 +74,6 @@ export default function(sWidth: string | number, isOSSImg: any): string {
     // isNum
     xWidth = sWidth;
   }
-  const newWidth = find(Math.floor(xWidth / scaling), scalingWidth);
+  const newWidth = find(Math.floor(xWidth / scaling));
   return newWidth ? isOSSImg ? `_${newWidth}w` : `${newWidth}x10000` : '';
 }


### PR DESCRIPTION
在图片后缀尺寸拼接的判断逻辑中，原有 return false 的方式会中断后缀的对比逻辑，导致图片尺寸异常。