### PR TITLE
Fix slider auto play when children length is 1

### DIFF
--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-slider",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -46,13 +46,13 @@
     "rax": "^1.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.3",
     "@rax-types/rax": "^1.0.5",
     "@types/ali-app": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/jest": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
+    "babel-eslint": "^10.0.3",
     "csstype": "^2.6.4",
     "driver-universal": "^1.0.0",
     "eslint": "^5.10.0",
@@ -61,6 +61,7 @@
     "eslint-plugin-react": "~7.11.1",
     "jest-localstorage-mock": "^2.3.0",
     "rax": "^1.0.0",
+    "rax-image": "^2.1.0",
     "rax-plugin-component": "^0.1.9",
     "rax-scripts": "^2.0.0",
     "rax-test-renderer": "^1.0.0",

--- a/packages/rax-slider/src/slider.web.tsx
+++ b/packages/rax-slider/src/slider.web.tsx
@@ -76,7 +76,7 @@ class Slider extends Component<SliderProps, any> {
 
   private autoPlay() {
     const autoPlayInterval = this.props.autoPlayInterval;
-    if (this.isSwiping || this.total < 2 ) return;
+    if (this.isSwiping) return;
     this.autoPlayTimer && clearInterval(this.autoPlayTimer);
     const interval = () => {
       if (this.isLoopEnd()) return;
@@ -220,7 +220,7 @@ class Slider extends Component<SliderProps, any> {
       width: this.width + 'rpx',
       height: this.height + 'rpx'
     };
-    return this.total !== 0 ? (
+    return this.total > 1  ? (
       <SwipeEvent
         className="rax-slider-swipe-wrapper"
         style={style}

--- a/packages/rax-slider/src/slider.web.tsx
+++ b/packages/rax-slider/src/slider.web.tsx
@@ -76,7 +76,7 @@ class Slider extends Component<SliderProps, any> {
 
   private autoPlay() {
     const autoPlayInterval = this.props.autoPlayInterval;
-    if (this.isSwiping) return;
+    if (this.isSwiping || this.total < 2 ) return;
     this.autoPlayTimer && clearInterval(this.autoPlayTimer);
     const interval = () => {
       if (this.isLoopEnd()) return;
@@ -244,10 +244,10 @@ class Slider extends Component<SliderProps, any> {
         </View>
       </SwipeEvent>
     ) : (
-      <View ref={this.swipeView} className="rax-slider-swipe" style={style}>
-        {pages}
-      </View>
-    );
+        <View ref={this.swipeView} className="rax-slider-swipe" style={style}>
+          {pages}
+        </View>
+      );
   }
 
   public render() {


### PR DESCRIPTION
rax-slider shouldn't autoPlay and swiped when children length is less than 2. 