### PR TITLE
fix: wechat canvas type

### DIFF
--- a/packages/rax-canvas/README.md
+++ b/packages/rax-canvas/README.md
@@ -35,6 +35,7 @@ $ npm install rax-canvas --save
 返回画布实例。
 
 type 默认值为 `2d`，目前在小程序中暂不支持设置。
+由于微信小程序新接口获取 `canvas context` 是一个异步行为，如果想获得设置 `2d`/`webgl` 的能力，则不能使用 `getContext` 方法，需要用户自己兼容处理，具体详见微信小程序文档 https://developers.weixin.qq.com/miniprogram/dev/component/canvas.html。
 
 ## 注意
 直接指定 `width` 或者 `height` 的优先级高于在 `style` 和 `className` 中指定的宽高。

--- a/packages/rax-canvas/README.md
+++ b/packages/rax-canvas/README.md
@@ -34,7 +34,7 @@ $ npm install rax-canvas --save
 ### getContext(type: string)
 返回画布实例。
 
-type 默认值为 `2d`，目前在微信小程序中仅支持 `2d`/`webgl`，在阿里小程序中暂不支持设置。
+type 默认值为 `2d`，目前在小程序中暂不支持设置。
 
 ## 注意
 直接指定 `width` 或者 `height` 的优先级高于在 `style` 和 `className` 中指定的宽高。

--- a/packages/rax-canvas/package.json
+++ b/packages/rax-canvas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rax-canvas",
   "author": "rax",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Canvas for Rax.",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/packages/rax-canvas/src/wechat-miniprogram/index.js
+++ b/packages/rax-canvas/src/wechat-miniprogram/index.js
@@ -24,6 +24,7 @@ Component({
     },
     type: {
       type: String,
+      // Compatible with old interface, type should be an empty string
       value: ''
     }
   },

--- a/packages/rax-canvas/src/wechat-miniprogram/index.js
+++ b/packages/rax-canvas/src/wechat-miniprogram/index.js
@@ -21,6 +21,10 @@ Component({
     height: {
       type: Number,
       value: 0
+    },
+    type: {
+      type: String,
+      value: ''
     }
   },
   options: {
@@ -51,7 +55,7 @@ Component({
       const event = fmtEvent(this.properties, e);
       this.triggerEvent('onTouchCancel', event.detail);
     },
-    getContext(type) {
+    getContext() {
       const context = wx.createCanvasContext(this.properties.componentId, this);
       Object.defineProperty(context, 'fillStyle', {
         get() {

--- a/packages/rax-canvas/src/wechat-miniprogram/index.js
+++ b/packages/rax-canvas/src/wechat-miniprogram/index.js
@@ -21,10 +21,6 @@ Component({
     height: {
       type: Number,
       value: 0
-    },
-    type: {
-      type: String,
-      value: '2d'
     }
   },
   options: {
@@ -56,11 +52,6 @@ Component({
       this.triggerEvent('onTouchCancel', event.detail);
     },
     getContext(type) {
-      if (type && this.data.type !== type) {
-        this.setData({
-          type
-        });
-      }
       const context = wx.createCanvasContext(this.properties.componentId, this);
       Object.defineProperty(context, 'fillStyle', {
         get() {

--- a/packages/rax-canvas/src/wechat-miniprogram/index.wxml
+++ b/packages/rax-canvas/src/wechat-miniprogram/index.wxml
@@ -1,4 +1,5 @@
 <canvas
+  type="{{type}}"
   class="{{className}}"
   style="{{styleSheet}}"
   id="{{componentId}}"

--- a/packages/rax-canvas/src/wechat-miniprogram/index.wxml
+++ b/packages/rax-canvas/src/wechat-miniprogram/index.wxml
@@ -1,5 +1,4 @@
 <canvas
-  type="{{type}}"
   class="{{className}}"
   style="{{styleSheet}}"
   id="{{componentId}}"


### PR DESCRIPTION
微信小程序使用 `wx.createCanvasContext` 时，组件 `type` 必须为空，否则画布不会绘制