### PR TITLE
fix: default keyboardType behave different across web and miniapp

### DIFF
--- a/packages/rax-textinput/src/miniapp-wechat/index.ts
+++ b/packages/rax-textinput/src/miniapp-wechat/index.ts
@@ -1,5 +1,11 @@
 import fmtEvent from './fmtEvent';
 
+const supportKeyboardTypes = [
+  'text',
+  'number',
+  'idcard',
+  'digit',
+];
 const defaultKeyboardType = 'text';
 
 Component({
@@ -83,19 +89,31 @@ Component({
   options: {
     styleIsolation: 'apply-shared',
   },
+  observers: {
+    'keyboardType': function(value) {
+      const { keyboardType } = this.properties;
+      const preKeyboardType = this.getKeyboardType(keyboardType);
+      const currentKeyboardType = this.getKeyboardType(value);
+
+      if (preKeyboardType !== currentKeyboardType) {
+        this.setData({
+          keyboardType: currentKeyboardType,
+        });
+      }
+    }
+  },
   attached() {
     const { value, defaultValue, keyboardType } = this.properties;
-    const supportKeyboardTypes = [
-      'text',
-      'number',
-      'idcard',
-      'digit',
-    ];
-    this.setData({
+    const currentKeyboardType = this.getKeyboardType(keyboardType);
+    const data = {
       previousValue: value || defaultValue,
-      keyboardType: supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
-        keyboardType : defaultKeyboardType,
-    });
+    };
+    if (currentKeyboardType !== keyboardType) {
+      Object.assign(data, {
+        keyboardType: currentKeyboardType,
+      });
+    }
+    this.setData(data);
   },
   methods: {
     onBlur(e) {
@@ -120,6 +138,10 @@ Component({
     onInput(e) {
       const event = fmtEvent(this.properties, e);
       this.triggerEvent('onInput', event);
-    }
+    },
+    getKeyboardType(keyboardType) {
+      return supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
+        keyboardType : defaultKeyboardType;
+    },
   }
 });

--- a/packages/rax-textinput/src/miniapp-wechat/index.ts
+++ b/packages/rax-textinput/src/miniapp-wechat/index.ts
@@ -1,5 +1,7 @@
 import fmtEvent from './fmtEvent';
 
+const defaultKeyboardType = 'text';
+
 Component({
   data: {
     previousValue: ''
@@ -35,7 +37,7 @@ Component({
     },
     keyboardType: {
       type: String,
-      value: 'text'
+      value: defaultKeyboardType
     },
     maxLength: {
       type: Number,
@@ -82,9 +84,17 @@ Component({
     styleIsolation: 'apply-shared',
   },
   attached() {
-    const { value, defaultValue } = this.properties;
+    const { value, defaultValue, keyboardType } = this.properties;
+    const supportKeyboardTypes = [
+      'text',
+      'number',
+      'idcard',
+      'digit',
+    ];
     this.setData({
-      previousValue: value || defaultValue
+      previousValue: value || defaultValue,
+      keyboardType: supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
+        keyboardType : defaultKeyboardType,
     });
   },
   methods: {

--- a/packages/rax-textinput/src/miniapp/index.ts
+++ b/packages/rax-textinput/src/miniapp/index.ts
@@ -2,6 +2,8 @@ import fmtEvent from './fmtEvent';
 
 function noop() {}
 
+const defaultKeyboardType = 'text';
+
 Component({
   data: {
     previousValue: ''
@@ -13,7 +15,7 @@ Component({
     multiline: false,
     autoFocus: false,
     editable: true,
-    keyboardType: 'default',
+    keyboardType: defaultKeyboardType,
     maxLength: '',
     placeholder: '',
     password: false,
@@ -35,9 +37,20 @@ Component({
     onConfirm: noop
   },
   didMount() {
-    const { value, defaultValue } = this.props;
+    const { value, defaultValue, keyboardType } = this.props;
+    const supportKeyboardTypes = [
+      'text',
+      'number',
+      'idcard',
+      'digit',
+      'numberpad',
+      'digitpad',
+      'idcardpad',
+    ];
     this.setData({
-      previousValue: value || defaultValue
+      previousValue: value || defaultValue,
+      keyboardType: supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
+        keyboardType : defaultKeyboardType,
     });
   },
   methods: {

--- a/packages/rax-textinput/src/miniapp/index.ts
+++ b/packages/rax-textinput/src/miniapp/index.ts
@@ -2,6 +2,15 @@ import fmtEvent from './fmtEvent';
 
 function noop() {}
 
+const supportKeyboardTypes = [
+  'text',
+  'number',
+  'idcard',
+  'digit',
+  'numberpad',
+  'digitpad',
+  'idcardpad',
+];
 const defaultKeyboardType = 'text';
 
 Component({
@@ -38,20 +47,26 @@ Component({
   },
   didMount() {
     const { value, defaultValue, keyboardType } = this.props;
-    const supportKeyboardTypes = [
-      'text',
-      'number',
-      'idcard',
-      'digit',
-      'numberpad',
-      'digitpad',
-      'idcardpad',
-    ];
-    this.setData({
+    const currentKeyboardType = this.getKeyboardType(keyboardType);
+    const data = {
       previousValue: value || defaultValue,
-      keyboardType: supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
-        keyboardType : defaultKeyboardType,
-    });
+    };
+    if (currentKeyboardType !== keyboardType) {
+      Object.assign(data, {
+        keyboardType: currentKeyboardType,
+      });
+    }
+    this.setData(data);
+  },
+  didUpdate(preProps) {
+    const preKeyboardType = this.getKeyboardType(preProps.keyboardType);
+    const currentKeyboardType = this.getKeyboardType(this.props.keyboardType);
+
+    if (preKeyboardType !== currentKeyboardType) {
+      this.setData({
+        keyboardType: currentKeyboardType,
+      });
+    }
   },
   methods: {
     trigger(type, value) {
@@ -79,6 +94,10 @@ Component({
     onInput(e) {
       const event = fmtEvent(this.props, e);
       this.trigger('onInput', event);
-    }
+    },
+    getKeyboardType(keyboardType) {
+      return supportKeyboardTypes.indexOf(keyboardType) !== -1 ?
+        keyboardType : defaultKeyboardType;
+    },
   }
 });


### PR DESCRIPTION
* issue: https://work.aone.alibaba-inc.com/issue/26039370 
* 原因：当前 rax-textInput 组件支付宝小程序默认 keyboardType 设置的是 default，为不支持的值，支付宝小程序会将其解析成 number 类型，默认值与 web 和微信小程序不一致（text 类型），导致多端投放时当未设置 keyboardType 时行为不一致
* fix: 
 抹平 web 与支付宝、微信 miniapp 三端 keyboardType 默认值差异
   1. 支付宝 miniapp 默认值改为 text
   2. 支付宝、微信 miniapp 端设置不支持的 keyboardType 时转成默认值