### PR TITLE
chore: remove miniapp text default style

### DIFF
--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-text",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-text/src/miniapp/index.acss
+++ b/packages/rax-text/src/miniapp/index.acss
@@ -1,6 +1,0 @@
-.rax-text {
-  box-sizing: border-box;
-  display: block;
-  font-size: 32rpx;
-  white-space: pre-wrap;
-}

--- a/packages/rax-text/src/miniapp/index.axml
+++ b/packages/rax-text/src/miniapp/index.axml
@@ -1,4 +1,4 @@
-<text class="rax-text {{className}}" 
+<text class="{{className}}" 
     style="{{style}}" 
     number-of-lines="{{numberOfLines}}"
     selectable="{{selectable}}"


### PR DESCRIPTION
### 背景
rax-text@1.2.0 及以前的版本中，小程序的实现样式为 inline，表现和 Web 不一致，在 1.3.0 的版本中对齐了表现，但是导致 1.2.0 及以前的版本的业务出现 break 的兼容问题。故目前需要回退到 1.2.0 以前的代码，并在 2.0 之后的版本对齐其它端的表现。