### PR TITLE
fix: time duration in miniapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,11 @@
     "@babel/preset-env": "7.2.0",
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
-    "rax-types": "^1.0.0",
     "@types/ali-app": "^1.0.0",
     "@types/jest": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
     "axios": "^0.19.0",
-    "semver": "^6.3.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
@@ -47,8 +45,11 @@
     "minimist": "^1.2.0",
     "rax": "^1.0.0",
     "rax-test-renderer": "^1.0.0",
+    "rax-types": "^1.0.0",
+    "semver": "^6.3.0",
     "semver-regex": "^2.0.0",
-    "shelljs": "0.8.3"
+    "shelljs": "0.8.3",
+    "typescript": "^3.8.3"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "@babel/preset-env": "7.2.0",
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
+    "rax-types": "^1.0.0",
     "@types/ali-app": "^1.0.0",
     "@types/jest": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
     "axios": "^0.19.0",
+    "semver": "^6.3.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
@@ -45,11 +47,8 @@
     "minimist": "^1.2.0",
     "rax": "^1.0.0",
     "rax-test-renderer": "^1.0.0",
-    "rax-types": "^1.0.0",
-    "semver": "^6.3.0",
     "semver-regex": "^2.0.0",
-    "shelljs": "0.8.3",
-    "typescript": "^3.8.3"
+    "shelljs": "0.8.3"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",

--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -56,7 +56,7 @@
     "rax-plugin-component": "^0.1.25",
     "rax-scripts": "^2.0.0",
     "rax-test-renderer": "^1.0.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.8.3"
   },
   "miniappConfig": {
     "main": "lib/miniapp/index",

--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-countdown",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Countdown component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -55,7 +55,8 @@
     "rax": "^1.0.0",
     "rax-plugin-component": "^0.1.25",
     "rax-scripts": "^2.0.0",
-    "rax-test-renderer": "^1.0.0"
+    "rax-test-renderer": "^1.0.0",
+    "typescript": "^3.9.2"
   },
   "miniappConfig": {
     "main": "lib/miniapp/index",

--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -55,8 +55,7 @@
     "rax": "^1.0.0",
     "rax-plugin-component": "^0.1.25",
     "rax-scripts": "^2.0.0",
-    "rax-test-renderer": "^1.0.0",
-    "typescript": "^3.8.3"
+    "rax-test-renderer": "^1.0.0"
   },
   "miniappConfig": {
     "main": "lib/miniapp/index",

--- a/packages/rax-countdown/src/index.js
+++ b/packages/rax-countdown/src/index.js
@@ -9,7 +9,8 @@ function isFunction(functionToCheck) {
   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
 };
 
-function addZero(num, timeWrapStyle, timeBackground, timeBackgroundStyle, timeStyle, secondStyle) {
+function Time(props) {
+  const { num, timeWrapStyle, timeBackground, timeBackgroundStyle, timeStyle, secondStyle } = props;
   const displayNum = num < 0 ? 0 : num;
   const displayFirstNum = displayNum < 10 ? 0 : displayNum.toString().slice(0, 1);
   const displaySecondNum = displayNum < 10 ? displayNum : displayNum.toString().slice(1);
@@ -166,7 +167,7 @@ class Index extends Component {
           if (val === -1) {// don't forget the potential plain text after last matched item
             const lastPlaintext = tpl.slice(lastPlaintextIndex);
             return lastPlaintext ? (
-              <Text style={textStyle}>{lastPlaintext}</Text>
+              <Text style={textStyle} key={`text_${index}`}>{lastPlaintext}</Text>
             ) : null;
           }
 
@@ -181,10 +182,18 @@ class Index extends Component {
                 // eg. in `{d}-{h}`:  text before `{d}` is ``, text before `{h}` is `-`
                 const preText = tpl.slice(lastPlaintextIndex, val);
                 // Do not generate text node if there is no preText
-                return preText ? <Text style={textStyle}>{preText}</Text> : null;
+                return preText ? <Text style={textStyle} key={`text_${index}`}>{preText}</Text> : null;
               } else {// replace current matched item to realtime string
                 lastPlaintextIndex = val + 3;
-                return addZero(timeType[matchedCharacter], timeWrapStyle, timeBackground, timeBackgroundStyle, timeStyle, secondStyle);
+                return <Time
+                  num={timeType[matchedCharacter]}
+                  timeWrapStyle={timeWrapStyle}
+                  timeBackground={timeBackground}
+                  timeBackgroundStyle={timeBackgroundStyle}
+                  timeStyle={timeStyle}
+                  secondStyle={secondStyle}
+                  key={`time_${index}`}
+                />;
               }
             default:
               return null;

--- a/packages/rax-countdown/src/miniapp/index.axml
+++ b/packages/rax-countdown/src/miniapp/index.axml
@@ -1,13 +1,17 @@
+<!-- [{"value":["3","5"],"style":"","isTime":true},{"value":"秒","style":""}] -->
 <view class="main-wrapper">
     <block a:for="{{parsedTime}}">
       <view style="{{item.style}}">
         <block a:if="{{item && item.value && item.value[0]}}">
+          <!-- render time, eg. {"value":["3","5"],"style":"","isTime":true} -->
           <block a:if="{{item.isTime}}">
             <block a:for="{{item.value}}" a:for-item="time" a:for-index="idx">
+              <!-- set style for second -->
               <text a:if="{{idx == item.value.length - 1 && index == parsedTime.length - 2}}" style="{{secondStyle || timeStyle}}">{{time}}</text>
               <text a:else style="{{timeStyle}}">{{time}}</text>
             </block>
           </block>
+          <!-- render text, eg, {"value":"秒","style":""} -->
           <text a:else style="{{timeStyle}}">{{item.value[0]}}</text>
         </block>
       </view>

--- a/packages/rax-countdown/src/miniapp/index.axml
+++ b/packages/rax-countdown/src/miniapp/index.axml
@@ -1,11 +1,14 @@
 <view class="main-wrapper">
     <block a:for="{{parsedTime}}">
       <view style="{{item.style}}">
-        <text a:if="{{item && item.value && item.value[0]}}"
-          style="{{timeStyle}}">{{item.value[0]}}</text>
-        <block a:if="{{item && item.value && item.value[1]}}">
-          <text a:if="{{item.isTime && index == parsedTime.length-2}}" style="{{secondStyle || timeStyle}}">{{item.value[1]}}</text>
-          <text a:else style="{{timeStyle}}">{{item.value[1]}}</text>
+        <block a:if="{{item && item.value && item.value[0]}}">
+          <block a:if="{{item.isTime}}">
+            <block a:for="{{item.value}}" a:for-item="time" a:for-index="idx">
+              <text a:if="{{idx == item.value.length - 1 && index == parsedTime.length - 2}}" style="{{secondStyle || timeStyle}}">{{time}}</text>
+              <text a:else style="{{timeStyle}}">{{time}}</text>
+            </block>
+          </block>
+          <text a:else style="{{timeStyle}}">{{item.value[0]}}</text>
         </block>
       </view>
     </block>

--- a/packages/rax-countdown/src/miniapp/index.ts
+++ b/packages/rax-countdown/src/miniapp/index.ts
@@ -37,7 +37,7 @@ Component({
         if (this.counter) clearInterval(this.counter);
       }
 
-      // return the integer
+      // parameter type of `parseInt` is 'string', so need to convert time to string first.
       var seconds = parseInt((timeDuration / 1000 % 60).toString()),
         minutes = parseInt((timeDuration / (1000 * 60) % 60).toString()),
         hours = parseInt((timeDuration / (1000 * 60 * 60) % 24).toString()),

--- a/packages/rax-countdown/src/miniapp/index.ts
+++ b/packages/rax-countdown/src/miniapp/index.ts
@@ -37,10 +37,11 @@ Component({
         if (this.counter) clearInterval(this.counter);
       }
 
-      var seconds = timeDuration / 1000 % 60,
-        minutes = timeDuration / (1000 * 60) % 60,
-        hours = timeDuration / (1000 * 60 * 60) % 24,
-        days = timeDuration / (1000 * 60 * 60 * 24);
+      // return the integer
+      var seconds = parseInt((timeDuration / 1000 % 60).toString()),
+        minutes = parseInt((timeDuration / (1000 * 60) % 60).toString()),
+        hours = parseInt((timeDuration / (1000 * 60 * 60) % 24).toString()),
+        days = parseInt((timeDuration / (1000 * 60 * 60 * 24)).toString());
 
       const timeType = {
         'd': days < 10 ? '0' + days : days + '',


### PR DESCRIPTION
1. Days larger than 99  is not displayed correctly in miniapp

correct：
![image](https://user-images.githubusercontent.com/1303018/81533398-b50c0f80-9398-11ea-8f7f-1ef485298bdf.png)

error：
![image](https://user-images.githubusercontent.com/1303018/81533373-a9b8e400-9398-11ea-986c-6702e97925de.png)

2. add key for items to avoid warning