### PR TITLE
Fix rax-scrollview container height

### DIFF
--- a/packages/rax-scrollview/demo/index.jsx
+++ b/packages/rax-scrollview/demo/index.jsx
@@ -11,7 +11,7 @@ import './index.css';
 
 function Thumb({ index }) {
   return (
-    <View id={"id_" + index} className="button">
+    <View id={'id_' + index} className="button">
       <View className="box">{index}</View>
     </View>
   );

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-scrollview",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-scrollview/src/index.css
+++ b/packages/rax-scrollview/src/index.css
@@ -9,6 +9,7 @@
 .rax-scrollview-content-container-horizontal {
     flex-direction: row;
 }
+
 .rax-scrollview-webcontainer {
-    display: block
+    display: block;
 }

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -187,7 +187,7 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
       ...style
     };
 
-    if (scrollerStyle.heigh === undefined) {
+    if (scrollerStyle.height === undefined) {
       scrollerStyle.flex = 1;
     }
     const cls = cx(

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -164,8 +164,8 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
       if (childLayoutProps.length !== 0) {
         console.warn(
           'ScrollView child layout (' +
-            JSON.stringify(childLayoutProps) +
-            ') must be applied through the contentContainerStyle prop.'
+          JSON.stringify(childLayoutProps) +
+          ') must be applied through the contentContainerStyle prop.'
         );
       }
     }
@@ -186,7 +186,8 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
     const scrollerStyle: CSSProperties = {
       ...style
     };
-    if (scrollerStyle.height === null) {
+
+    if (scrollerStyle.heigh === undefined) {
       scrollerStyle.flex = 1;
     }
     const cls = cx(
@@ -200,9 +201,9 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
     {
       if (
         !showsScrollIndicator &&
-          typeof document !== 'undefined' &&
-          typeof document.getElementById === 'function' &&
-          !document.getElementById(STYLE_NODE_ID)
+        typeof document !== 'undefined' &&
+        typeof document.getElementById === 'function' &&
+        !document.getElementById(STYLE_NODE_ID)
       ) {
         let styleNode = document.createElement('style');
         styleNode.id = STYLE_NODE_ID;

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -187,7 +187,7 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
       ...style
     };
 
-    if (scrollerStyle.height === undefined) {
+    if (scrollerStyle.height === null || scrollerStyle.height === undefined) {
       scrollerStyle.flex = 1;
     }
     const cls = cx(


### PR DESCRIPTION
This is demo from rax-scrollview, can't scroll and jump to target child element.
Fix this bug:

![image](https://user-images.githubusercontent.com/9896768/81887947-e07a3e80-95d2-11ea-954f-f2b8d4c7174c.png)
