### PR TITLE
fix: capitalize verdor prefix for SSR

### DIFF
--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-text",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -43,8 +43,8 @@
     "@typescript-eslint/parser": "^1.7.0",
     "build-plugin-rax-component": "^0.1.0",
     "csstype": "^2.6.4",
-    "driver-dom": "^1.0.0",
-    "driver-universal": "^1.0.1",
+    "driver-dom": "^2.0.0",
+    "driver-universal": "^3.0.0",
     "driver-weex": "^1.0.0",
     "eslint": "^5.16.0",
     "eslint-config-rax": "^0.0.0",

--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-text",
-  "version": "2.0.0",
+  "version": "1.3.1",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-text/src/index.tsx
+++ b/packages/rax-text/src/index.tsx
@@ -50,7 +50,8 @@ const Text: ForwardRefExoticComponent<TextProps> = forwardRef((props, ref) => {
         {...rest}
         ref={ref}
         className={classNames.join(' ')}
-        style={{ ...style, webkitLineClamp: lines > 1 ? lines : undefined }}
+        // Vendor prefixes should begin with a capital letter.
+        style={{ ...style, WebkitLineClamp: lines > 1 ? lines : undefined }}
         onClick={handleClick}
       >
         {textString}


### PR DESCRIPTION
According React's implement, vendor prefixes should begin with a capital letter.

In Rax Server Renderer followed this rule, so `webkitLineClamp` can not be render correctly.

But in driver-universal 1.x, `WebkitLineClamp` will be filtered，so this is a break change for apps still use driver-universal 1.x.

![image](https://user-images.githubusercontent.com/1303018/82528746-0de36100-9b6c-11ea-9aee-634671cd3ae4.png)

https://reactjs.org/docs/dom-elements.html#style

需要 breakchange 是因为，driver-universal 1.x 版本中对 `WebkitLineClamp` 的处理有问题，会为其转换上单位，因此改动后，rax-text 只能在新版本 driver 使用