### PR TITLE
fix(rax-modal): modal opacity

### DIFF
--- a/packages/rax-modal/demo/index.jsx
+++ b/packages/rax-modal/demo/index.jsx
@@ -17,6 +17,7 @@ const Demo = props => {
       </View>,
       <Modal
         visible={visible}
+        animation={false}
         onHide={() => {
           setVisible(false);
         }}

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "rax-modal",
   "main": "lib/index.js",
   "quickappConfig": {

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.5.1-2",
+  "version": "1.5.1",
   "description": "rax-modal",
   "main": "lib/index.js",
   "quickappConfig": {

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean && rax-scripts build",
     "start": "rax-scripts start",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && rax-scripts test"
+    "test": "rax-scripts test"
   },
   "repository": {
     "type": "git",
@@ -25,7 +25,10 @@
   "jest": {
     "moduleNameMapper": {
       "\\.(css|less|scss|sass)$": "jest-transform-css"
-    }
+    },
+    "setupFilesAfterEnv": [
+      "./setup.js"
+    ]
   },
   "engines": {
     "npm": ">=3.0.0"
@@ -46,6 +49,8 @@
     "@typescript-eslint/parser": "^1.7.0",
     "csstype": "^2.6.7",
     "driver-universal": "^1.0.2",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-rax": "^1.0.3",
     "eslint": "^5.16.0",
     "eslint-config-rax": "^0.0.0",
     "jest-transform-css": "^2.0.0",

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.5.1",
+  "version": "1.5.1-2",
   "description": "rax-modal",
   "main": "lib/index.js",
   "quickappConfig": {

--- a/packages/rax-modal/setup.js
+++ b/packages/rax-modal/setup.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-rax';
+
+
+// Setup Enzyme
+enzyme.configure({ adapter: new Adapter() });

--- a/packages/rax-modal/src/__tests__/modal.test.js
+++ b/packages/rax-modal/src/__tests__/modal.test.js
@@ -108,4 +108,34 @@ describe('render modal', () => {
     jest.runAllTimers();
     expect(showModal).toBe(false);
   });
+
+  it('onMaskClick should valid', () => {
+    let showModal = false;
+    function App() {
+      const [visible, setVisible] = useState(true);
+      showModal = true;
+      return (
+        <View>
+          <Modal
+            visible={visible}
+            onHide={() => {
+              showModal = false;
+              setVisible(false);
+            }}
+            animation={true}
+            onMaskClick={() => {
+              setVisible(false);
+            }}
+          >
+            <View>这里是弹窗内容</View>
+          </Modal>
+        </View>
+      );
+    }
+    const wrapper = mount(<App />);
+    expect(showModal).toBe(true);
+    wrapper.find('.rax-modal-mask').at(1).simulate('click');
+    jest.runAllTimers();
+    expect(showModal).toBe(false);
+  });
 });

--- a/packages/rax-modal/src/__tests__/modal.test.js
+++ b/packages/rax-modal/src/__tests__/modal.test.js
@@ -1,5 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { createElement, useState, useEffect } from 'rax';
-import renderer from 'rax-test-renderer';
+import { mount } from 'enzyme';
 import View from 'rax-view';
 import Modal from '../../lib';
 
@@ -37,7 +38,7 @@ describe('render modal', () => {
         </View>
       );
     }
-    renderer.create(<App />).toJSON();
+    mount(<App />);
     expect(showModal).toBe(false);
     jest.runAllTimers();
     expect(showModal).toBe(true);
@@ -70,7 +71,7 @@ describe('render modal', () => {
         </View>
       );
     }
-    renderer.create(<App />).toJSON();
+    mount(<App />);
     expect(showModal).toBe(false);
     jest.runAllTimers();
     expect(showModal).toBe(true);
@@ -102,7 +103,7 @@ describe('render modal', () => {
         </View>
       );
     }
-    renderer.create(<App />).toJSON();
+    mount(<App />);
     expect(showModal).toBe(true);
     jest.runAllTimers();
     expect(showModal).toBe(false);

--- a/packages/rax-modal/src/index.tsx
+++ b/packages/rax-modal/src/index.tsx
@@ -70,7 +70,7 @@ function Modal(props: ModalProps) {
     const animateDuration = show ? duration[0] : duration[1];
     // Record animation execute timer
     maskRef.__timer = setTimeout(() => {
-      if (show) {
+      if (show && maskRef.current) {
         // When target state is show, it need set modal opacity to 1
        maskRef.current.style.opacity = '1';
      }
@@ -88,7 +88,7 @@ function Modal(props: ModalProps) {
       },
       () => {
         clearTimeout(maskRef.__timer);
-        if (show) {
+        if (show && maskRef.current) {
           // When target state is show, it need set modal opacity to 1
           maskRef.current.style.opacity = '1';
         }
@@ -114,6 +114,7 @@ function Modal(props: ModalProps) {
           onShow && onShow();
         });
       } else {
+        maskRef.current.style.opacity = '1';
         onShow && onShow();
       }
     }
@@ -148,14 +149,14 @@ function Modal(props: ModalProps) {
     return () => {
       // When the modal unmounted modal mount --
       modalCount--;
+      // Clear timer
+      clearTimeout(maskRef.__timer);
       if (isWeb && modalCount === 0) {
         bodyEl.style.overflow = originalBodyOverflow;
       }
       if (!maskRef.__pendingHide) {
         onHide && onHide();
       }
-      // Clear timer
-      clearTimeout(maskRef.__timer);
     }
   }, [])
 

--- a/packages/rax-modal/src/index.tsx
+++ b/packages/rax-modal/src/index.tsx
@@ -70,14 +70,10 @@ function Modal(props: ModalProps) {
     const animateDuration = show ? duration[0] : duration[1];
     // Record animation execute timer
     const timer = setTimeout(() => {
-      // Only when target value unequal to visible trigger callback
-      if (show !== visible) {
-        if (show) {
-           // When target state is show, it need set modal opacity to 1
-          maskRef.current.style.opacity = '1';
-        }
-        callback && callback();
-      }
+      if (show) {
+        // When target state is show, it need set modal opacity to 1
+       maskRef.current.style.opacity = '1';
+     }
     }, animateDuration)
 
     transition(
@@ -96,9 +92,7 @@ function Modal(props: ModalProps) {
           // When target state is show, it need set modal opacity to 1
           maskRef.current.style.opacity = '1';
         }
-        if (show !== visible) {
-          callback && callback();
-        }
+        callback && callback();
       }
     );
   };
@@ -166,14 +160,7 @@ function Modal(props: ModalProps) {
   useEffect(() => {
     // if state is unequal to props trigger show or hide
     if (visible !== visibleState) {
-      if (!maskRef.__rendered) {
-        // Modal first render, visibleState initial value is false. However, when props'visible is false, it need execute show
-        visible && show();
-      } else {
-        visible ? show() : hide();
-      }
-      // Mark the modal has been rendered
-      maskRef.__rendered = true;
+      visible ? show() : hide();
     }
   }, [visible]);
 

--- a/packages/rax-modal/src/index.tsx
+++ b/packages/rax-modal/src/index.tsx
@@ -69,7 +69,7 @@ function Modal(props: ModalProps) {
   const animate = (show: boolean, callback: Function) => {
     const animateDuration = show ? duration[0] : duration[1];
     // Record animation execute timer
-    const timer = setTimeout(() => {
+    maskRef.__timer = setTimeout(() => {
       if (show) {
         // When target state is show, it need set modal opacity to 1
        maskRef.current.style.opacity = '1';
@@ -87,7 +87,7 @@ function Modal(props: ModalProps) {
         duration: animateDuration
       },
       () => {
-        clearTimeout(timer);
+        clearTimeout(maskRef.__timer);
         if (show) {
           // When target state is show, it need set modal opacity to 1
           maskRef.current.style.opacity = '1';
@@ -154,6 +154,8 @@ function Modal(props: ModalProps) {
       if (!maskRef.__pendingHide) {
         onHide && onHide();
       }
+      // Clear timer
+      clearTimeout(maskRef.__timer);
     }
   }, [])
 

--- a/packages/rax-modal/src/index.tsx
+++ b/packages/rax-modal/src/index.tsx
@@ -67,13 +67,16 @@ function Modal(props: ModalProps) {
   }
 
   const animate = (show: boolean, callback: Function) => {
+    maskRef.__animationValid = true;
     const animateDuration = show ? duration[0] : duration[1];
     // Record animation execute timer
     maskRef.__timer = setTimeout(() => {
+      maskRef.__animationValid = false;
       if (show && maskRef.current) {
         // When target state is show, it need set modal opacity to 1
        maskRef.current.style.opacity = '1';
-     }
+      }
+      callback && callback();
     }, animateDuration)
 
     transition(
@@ -87,12 +90,15 @@ function Modal(props: ModalProps) {
         duration: animateDuration
       },
       () => {
-        clearTimeout(maskRef.__timer);
-        if (show && maskRef.current) {
-          // When target state is show, it need set modal opacity to 1
-          maskRef.current.style.opacity = '1';
+        // Ensure animation timer hasn't been executed
+        if (maskRef.__animationValid) {
+          clearTimeout(maskRef.__timer);
+          if (show && maskRef.current) {
+            // When target state is show, it need set modal opacity to 1
+            maskRef.current.style.opacity = '1';
+          }
+          callback && callback();
         }
-        callback && callback();
       }
     );
   };

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -13,6 +13,7 @@ export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttribute
 }
 
 export interface MaskRef extends MutableRefObject<HTMLDivElement> {
+  __animationValid: boolean;
   __timer: ReturnType<typeof setTimeout>;
   __pendingShow: boolean;
   __pendingHide: boolean;

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -13,7 +13,7 @@ export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttribute
 }
 
 export interface MaskRef extends MutableRefObject<HTMLDivElement> {
-  __rendered: boolean;
+  __timer: ReturnType<typeof setTimeout>;
   __pendingShow: boolean;
   __pendingHide: boolean;
 }

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -13,6 +13,7 @@ export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttribute
 }
 
 export interface MaskRef extends MutableRefObject<HTMLDivElement> {
+  __rendered: boolean;
   __pendingShow: boolean;
   __pendingHide: boolean;
 }


### PR DESCRIPTION
1. 修复 modal 应该在 show 之后，将 opacity 终态设置为 1 的逻辑
2. 添加定时器兜底逻辑，当动画在动画过渡时间内没有执行回调时，即 universal-transition 失效时，强制执行回调