### PR TITLE
fix: gesture-view horizontal/vertical pan threadhold

### DIFF
--- a/packages/rax-gesture-view/package.json
+++ b/packages/rax-gesture-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-gesture-view",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Gesture component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-gesture-view/src/gesture.web.tsx
+++ b/packages/rax-gesture-view/src/gesture.web.tsx
@@ -2,8 +2,6 @@ import { createElement, Component } from 'rax';
 import View from 'rax-view';
 import { GestureViewProps, PanEvent, PanType } from './types';
 
-const threshold = 5;
-
 const touchActionRatio = 1 / 1;
 
 class GestureViewOnWeb extends Component<GestureViewProps> {
@@ -41,7 +39,7 @@ class GestureViewOnWeb extends Component<GestureViewProps> {
   }
 
   private onTouchMove = (e: PanEvent) => {
-    let { onHorizontalPan, onVerticalPan } = this.props;
+    let { onHorizontalPan, onVerticalPan, threshold = 5 } = this.props;
     let deltaX = e.changedTouches[0].clientX - this.startX;
     let deltaY = e.changedTouches[0].clientY - this.startY;
 
@@ -56,8 +54,7 @@ class GestureViewOnWeb extends Component<GestureViewProps> {
     if (
       onHorizontalPan &&
       Math.abs(deltaX) >= threshold &&
-      Math.abs(deltaY / deltaX) < touchActionRatio &&
-      Math.abs(this.maxDy) < threshold
+      Math.abs(deltaY / deltaX) < touchActionRatio
     ) {
       e.preventDefault();
       this.isPropagationStoppedX = true;
@@ -74,8 +71,7 @@ class GestureViewOnWeb extends Component<GestureViewProps> {
     } else if (
       onVerticalPan &&
       Math.abs(deltaY) >= threshold &&
-      Math.abs(deltaX / deltaY) < touchActionRatio &&
-      Math.abs(this.maxDx) < threshold
+      Math.abs(deltaX / deltaY) < touchActionRatio
     ) {
       e.preventDefault();
       this.isPropagationStoppedY = true;

--- a/packages/rax-gesture-view/src/types.ts
+++ b/packages/rax-gesture-view/src/types.ts
@@ -3,6 +3,7 @@ import { TouchList, TouchEvent, Touch } from 'rax';
 export interface GestureViewProps {
   onHorizontalPan: (e: PanEvent) => void;
   onVerticalPan: (e: PanEvent) => void;
+  threshold?: number;
 }
 
 export type PanType = 'x' | 'y';


### PR DESCRIPTION
1. 去掉 HorizontalPan 上关于垂直判断的逻辑 Math.abs(this.maxDy) < threshold
去掉 VerticalPan 上关于水平判断的逻辑 Math.abs(this.maxDx) < threshold

原因：
1. 已经有水平/垂直方向的 threshold 以及两个方向的 touchActionRatio 这两个条件判断
2. 在客户端的横滑容器内，如果前端组件不处理事件时就会被客户端内拦截，导致后续前端事件无法接收，例如在 HorizontalPan 内，如果加了垂直方向的判断，就会比较容易被端上拦截，导致后续横滑失效

2. 增加 threshold 的 props 透传