### PR TITLE
Fix cancelable false error

### DIFF
--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rax-slider",
   "author": "rax",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-slider/src/SwipeEvent.tsx
+++ b/packages/rax-slider/src/SwipeEvent.tsx
@@ -109,7 +109,7 @@ SwipeEventProps,
             : false;
 
           if (validHorizontal) {
-            evt.preventDefault && evt.preventDefault();
+            evt.cancelable && evt.preventDefault && evt.preventDefault();
             this.velocityProp = 'vx';
             this.distanceProp = 'dx';
             // left

--- a/packages/rax-slider/src/SwipeEvent.tsx
+++ b/packages/rax-slider/src/SwipeEvent.tsx
@@ -13,11 +13,11 @@ const directions = {
 };
 
 class SwipeEvent extends Component<
-  SwipeEventProps,
-  {
-    swipe: any;
-  }
-  > {
+SwipeEventProps,
+{
+  swipe: any;
+}
+> {
   public static propTypes = {
     onSwipeBegin: PropTypes.func,
     onSwipe: PropTypes.func,

--- a/packages/rax-slider/src/SwipeEvent.tsx
+++ b/packages/rax-slider/src/SwipeEvent.tsx
@@ -109,7 +109,9 @@ SwipeEventProps,
             : false;
 
           if (validHorizontal) {
-            // https://caniuse.com/#search=cancelable
+            // Use event cancelable(https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable)
+            // Fix error `Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.`
+            // Not all browser support it(https://caniuse.com/#search=cancelable)
             (evt.cancelable === undefined || evt.cancelable) && evt.preventDefault && evt.preventDefault();
             this.velocityProp = 'vx';
             this.distanceProp = 'dx';

--- a/packages/rax-slider/src/SwipeEvent.tsx
+++ b/packages/rax-slider/src/SwipeEvent.tsx
@@ -13,11 +13,11 @@ const directions = {
 };
 
 class SwipeEvent extends Component<
-SwipeEventProps,
-{
-  swipe: any;
-}
-> {
+  SwipeEventProps,
+  {
+    swipe: any;
+  }
+  > {
   public static propTypes = {
     onSwipeBegin: PropTypes.func,
     onSwipe: PropTypes.func,
@@ -109,7 +109,8 @@ SwipeEventProps,
             : false;
 
           if (validHorizontal) {
-            evt.cancelable && evt.preventDefault && evt.preventDefault();
+            // https://caniuse.com/#search=cancelable
+            (evt.cancelable === undefined || evt.cancelable) && evt.preventDefault && evt.preventDefault();
             this.velocityProp = 'vx';
             this.distanceProp = 'dx';
             // left


### PR DESCRIPTION
Fixed:
`Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.`