### PR TITLE
fix: rax-canvas module field

### DIFF
--- a/packages/rax-canvas/package.json
+++ b/packages/rax-canvas/package.json
@@ -1,10 +1,10 @@
 {
   "name": "rax-canvas",
   "author": "rax",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Canvas for Rax.",
   "main": "lib/index.js",
-  "module": "src/index.js",
+  "module": "es/index.js",
   "miniappConfig": {
     "main": "lib/miniapp/index",
     "main:wechat": "lib/wechat-miniprogram/index",


### PR DESCRIPTION
1. rax-canvas should build es dir
2. Use `es/index.js` instead of `src/index.js` as rax-canvas `module` field's value