### PR TITLE
fix(rax-recyclerview): onScroll triggers incorrect event in wechat

### DIFF
--- a/packages/rax-recyclerview/package.json
+++ b/packages/rax-recyclerview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-recyclerview",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "RecyclerView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-recyclerview/src/miniapp-wechat/index.ts
+++ b/packages/rax-recyclerview/src/miniapp-wechat/index.ts
@@ -25,7 +25,7 @@ Component({
     },
     onScroll(e) {
       const event = fmtEvent(this.properties, e);
-      this.triggerEvent('onEndReached', event);
+      this.triggerEvent('onScroll', event);
     }
   }
 });


### PR DESCRIPTION
recyclerview onScroll triggers the onEndReached event incorrectly in wechat miniapp