### PR TITLE
fix: input editable

### DIFF
--- a/packages/rax-textinput/package.json
+++ b/packages/rax-textinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-textinput",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "TextInput component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-textinput/src/index.tsx
+++ b/packages/rax-textinput/src/index.tsx
@@ -107,7 +107,7 @@ const TextInput: ForwardRefExoticComponent<TextInputProps> = forwardRef(
       'aria-label': accessibilityLabel,
       autoComplete: autoComplete && 'on',
       maxlength: maxlength || maxLength,
-      readOnly: editable !== undefined && !editable,
+      readonly: editable !== undefined && !editable,
       onChange: (onChange || onChangeText) && handleChange,
       onInput: (e: InputEvent) => {
         onInput && handleInput(e);
@@ -120,7 +120,7 @@ const TextInput: ForwardRefExoticComponent<TextInputProps> = forwardRef(
       ref: refEl
     };
     // Diff with web readonly attr, `disabled` must be boolean value
-    const disbaled = isWeex ? Boolean(propsCommon.readOnly) : false;
+    const disbaled = Boolean(propsCommon.readonly);
     const rows = numberOfLines || maxNumberOfLines;
 
     useImperativeHandle(ref, () => {


### PR DESCRIPTION
`readonly` and `disabled` standardizing