### PR TITLE
fix(video): props transform in runtime miniapp

### DIFF
--- a/packages/rax-video/package.json
+++ b/packages/rax-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-video",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Video component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-video/src/index.tsx
+++ b/packages/rax-video/src/index.tsx
@@ -11,6 +11,15 @@ import cx from 'classnames/dedupe';
 import omit from 'omit.js';
 import { VideoProps } from './types';
 
+const miniappVideoPropsMap = {
+  showMuteBtn: 'show-mute-btn',
+  showPlayBtn: 'show-play-btn',
+  showFullscreenBtn: 'show-fullscreen-btn',
+  showCenterPlayBtn: 'show-center-play-btn',
+  showThinProgressBar: 'show-thin-progress-bar',
+  objectFit: 'object-fit'
+};
+
 const Video: ForwardRefExoticComponent<VideoProps> = forwardRef(
   (props, ref) => {
     const { className, style, controls, playControl, autoPlay } = props;
@@ -30,6 +39,12 @@ const Video: ForwardRefExoticComponent<VideoProps> = forwardRef(
     if (isWeChatMiniProgram || isMiniApp) {
       common.autoplay = common.autoPlay;
       delete common.autoPlay;
+
+      Object.keys(miniappVideoPropsMap).forEach(prop => {
+        common[miniappVideoPropsMap[prop]] = common[prop];
+        delete common[prop];
+      })
+
     }
 
     useEffect(() => {


### PR DESCRIPTION
- [x] 抹平 rax-video 在运行时小程序中驼峰式和连字符属性配置的差异