### PR TITLE
fix(TextInput): check input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2020-12-09
+
+### rax-textinput [1.3.8]
+
+#### Changed
+- In Alibaba Miniapp runtime, TextInput will check is `type` supported or not
+
 ## 2020-12-03
 
 ### rax-portal [1.0.0]

--- a/packages/rax-textinput/package.json
+++ b/packages/rax-textinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-textinput",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "TextInput component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-textinput/src/index.tsx
+++ b/packages/rax-textinput/src/index.tsx
@@ -88,7 +88,8 @@ const TextInput: ForwardRefExoticComponent<TextInputProps> = forwardRef(
       : keyboardTypeMap[keyboardType];
 
     // Check is type supported or not
-    if (isMiniApp && typeof my !== 'undefined') {
+    // Use isWeb to exclude web-view
+    if (isMiniApp && !isWeb) {
       const basicSupportTypes = ['text', 'number', 'idcard', 'digit'];
       // Other types, like numberpad, we can check it with canIUse
       if (!basicSupportTypes.includes(type) && !my.canIUse(`input.type.${type}`)) {

--- a/packages/rax-textinput/src/index.tsx
+++ b/packages/rax-textinput/src/index.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   useState
 } from 'rax';
-import { isWeex, isWeb, isWeChatMiniProgram, isNode } from 'universal-env';
+import { isWeex, isWeb, isWeChatMiniProgram, isNode, isMiniApp } from 'universal-env';
 import setNativeProps from 'rax-set-native-props';
 import keyboardTypeMap from './keyboardTypeMap';
 import {
@@ -80,8 +80,23 @@ const TextInput: ForwardRefExoticComponent<TextInputProps> = forwardRef(
       defaultValue,
       controlled
     } = props;
-    const type =
-      password || secureTextEntry ? 'password' : keyboardTypeMap[keyboardType];
+    let type =
+      password || secureTextEntry
+      ? "password"
+      : typeof keyboardTypeMap[keyboardType] === "undefined"
+      ? keyboardType
+      : keyboardTypeMap[keyboardType];
+
+    // Check is type supported or not
+    if (isMiniApp && typeof my !== 'undefined') {
+      const basicSupportTypes = ['text', 'number', 'idcard', 'digit'];
+      // Other types, like numberpad, we can check it with canIUse
+      if (!basicSupportTypes.includes(type) && !my.canIUse(`input.type.${type}`)) {
+        // If not support, fallback to text
+        type = 'text';
+      }
+    }
+
     const setValue = (value = '') => {
       setNativeProps(refEl.current, { value });
     };


### PR DESCRIPTION
支付宝所支持的类型有限，但实际上传入不支持的类型会导致其他情况出现。

例如支付宝原生并不支持type=search。使用Rax编写多端应用时，传入了keyboardType=web-search，在Web上表现正常，但在支付宝小程序中会导致iOS只能唤起数字键盘。

修复方式是进行二次检查。支付宝默认支持text、 number、 idcard、 digit 四种类型。其他类型（包括 numberpad、digitpad、 idcardpad）和后续继续增加更多的类型，可以通过canIUse进行判断。如果不支持，则fallback到text