### PR TITLE
fix: slideTo and index

### DIFF
--- a/packages/rax-slider/CHANGELOG.md
+++ b/packages/rax-slider/CHANGELOG.md
@@ -4,3 +4,4 @@
 - [fix] Method `slideTo` not as expected problem.
 - [fix] Props `index` not work in first rendering.
 - [feat] Update slide animation.
+- [feat] Update component`rax-view`.

--- a/packages/rax-slider/CHANGELOG.md
+++ b/packages/rax-slider/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2.4.0
+- [fix] Method `slideTo` not as expected problem.
+- [fix] Props `index` not work in first rendering.
+- [feat] Update slide animation.

--- a/packages/rax-slider/demo/index.jsx
+++ b/packages/rax-slider/demo/index.jsx
@@ -30,8 +30,11 @@ class App extends Component {
   }
 
   onClick = (direction) => {
-    this.inputRef.current.slideTo(this.inputRef.current.index,
-      direction === 'prev' ? 'SWIPE_RIGHT' : 'SWIPE_LEFT');
+    if (direction === 'go(0)') {
+      this.inputRef.current.slideTo(0);
+    } else {
+      this.inputRef.current.slideTo(this.inputRef.current.index + (direction === 'prev' ? -1 : 1));
+    }
   }
 
   render() {
@@ -42,7 +45,7 @@ class App extends Component {
           width={750}
           height={500}
           autoPlay={true}
-          index={0}
+          index={2}
           loop={true}
           speed={300}
           cssEase="linear"
@@ -72,6 +75,7 @@ class App extends Component {
         }}>
           <View onClick={this.onClick.bind(this, 'prev')}>prev</View>
           <View onClick={this.onClick.bind(this, 'next')}>next</View>
+          <View onClick={this.onClick.bind(this, 'go(0)')}>go(0)</View>
         </View>
       </View>
     );

--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rax-slider",
   "author": "rax",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -46,7 +46,7 @@
     "rax-children": "^1.0.0",
     "rax-clone-element": "^1.0.0",
     "rax-find-dom-node": "^1.0.0",
-    "rax-view": "^1.1.0-0",
+    "rax-view": "^2.0.0",
     "universal-env": "^3.2.0",
     "universal-panresponder": "^0.6.5"
   },

--- a/packages/rax-slider/src/slider.web.tsx
+++ b/packages/rax-slider/src/slider.web.tsx
@@ -84,25 +84,22 @@ class Slider extends Component<SliderProps, any> {
     this.autoPlayTimer && clearInterval(this.autoPlayTimer);
     const interval = () => {
       if (this.isLoopEnd()) return;
-      this.slideTo(this.index, SWIPE_LEFT);
+      this.slideTo(this.index + 1);
     };
     this.autoPlayTimer = setInterval(interval, autoPlayInterval);
   }
 
-  public slideTo(index: number, direction: string) {
+  public slideTo(index: number) {
+    if (this.index === index) return;
     if (this.isInTransition) return;
     if (this.isSwiping) return;
     if (this.total < 2) return;
 
-    if (direction) {
-      this.index = direction === SWIPE_LEFT ? index + 1 : index - 1;
-    } else {
-      this.index = index;
-    }
+    this.index = index;
 
     // Reset slider container's index when out of edge
     if (this.index > this.total) {
-      this.index = 1;
+      this.index = 0;
     }
     if (this.index < -1) {
       this.index = this.total - 1;
@@ -164,7 +161,7 @@ class Slider extends Component<SliderProps, any> {
           realIndex === 0 && direction === SWIPE_RIGHT)
       )
     ) {
-      this.slideTo(this.index, direction);
+      this.slideTo(this.index + (direction === 'SWIPE_LEFT' ? 1 : -1));
     }
     if (this.props.autoPlay) {
       this.autoPlay();


### PR DESCRIPTION
# Changelog

## 2.4.0
- [fix] Method `slideTo` not as expected problem.
- [fix] Props `index` not work in first rendering.
- [feat] Update slide animation.
- [feat] Update component`rax-view`.

对齐文档说明 https://rax.js.org/docs/components/slider 
![image](https://user-images.githubusercontent.com/9896768/102343427-82349480-3fd5-11eb-945f-a7f715ed1e82.png)
