### PR TITLE
feat(jsx2mp): add miniprogram config to support used in wechat

### DIFF
--- a/packages/rax-canvas/package.json
+++ b/packages/rax-canvas/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-canvas",
   "author": "rax",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Canvas for Rax.",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "miniprogram": ".",
   "miniappConfig": {
     "main": "lib/miniapp/index",
     "main:wechat": "lib/wechat-miniprogram/index",

--- a/packages/rax-embed/package.json
+++ b/packages/rax-embed/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-embed",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Embed container for Rax.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",

--- a/packages/rax-icon/package.json
+++ b/packages/rax-icon/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-icon",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "icon component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "miniappConfig": {
     "main:quickapp": "lib/quickapp/index",
     "main": "lib/miniapp/index",

--- a/packages/rax-image/package.json
+++ b/packages/rax-image/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-image",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Image component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./lib ./package-lock.json ./demo/miniapp/lib ",

--- a/packages/rax-link/package.json
+++ b/packages/rax-link/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-link",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Link component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",

--- a/packages/rax-qrcode/package.json
+++ b/packages/rax-qrcode/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-qrcode",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "QRCode component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-scrollview",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "quickappConfig": {
     "main": "lib/quickapp/index"
   },

--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-slider",
   "author": "rax",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "miniappConfig": {
     "main": "lib/miniapp/index",
     "main:wechat": "lib/wechat-miniprogram/index",

--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-text",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build",

--- a/packages/rax-textinput/package.json
+++ b/packages/rax-textinput/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-textinput",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "TextInput component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "quickappConfig": {
     "main": "lib/quickapp/index"
   },

--- a/packages/rax-video/package.json
+++ b/packages/rax-video/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-video",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Video component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",


### PR DESCRIPTION
- [x] package.json 中添加 miniprogram 字段用于微信小程序 IDE 构建 npm，确保 Rax 基础组件在微信小程序中可以使用