### PR TITLE
Release/miniapp components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 2020-01-13
+## 2021-01-28
+
+### rax-modal [1.5.6]
+
+#### Changed
+
+- add onMaskClick types
+
+## 2021-01-13
 
 ### rax-text [2.0.5]
 
@@ -11,11 +19,13 @@
 ### rax-countdown [1.1.5]
 
 #### Fixed
+
 - not clear interval when the component unmounted
 
-## 2020-01-12
+## 2021-01-12
 
 ### rax-portal [1.0.1]
+
 - Fix: not re-render when the container changes
 
 ## 2020-12-29
@@ -23,11 +33,13 @@
 ### rax-embed [1.1.2]
 
 #### Added
+
 - Support passing `id` prop to web-view component in miniapp
 
 ## 2020-12-18
 
 ### rax-image [2.2.4]
+
 - Support `loading` property in Web and Miniapp
 
 ## 2020-12-09
@@ -35,6 +47,7 @@
 ### rax-textinput [1.3.8]
 
 #### Changed
+
 - In Alibaba Miniapp runtime, TextInput will check is `type` supported or not
 
 ## 2020-12-03
@@ -42,10 +55,12 @@
 ### rax-portal [1.0.0]
 
 #### Changed
+
 - Add rax-portal component
 
 ## 2020-12-02
 
 ### rax-modal [1.5.5] 
 #### Changed
+
 - Fix the bug that onMaskClick can't work in alibaba miniapp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2020-01-13
+
+### rax-countdown [1.1.5]
+
+#### Fixed
+- not clear interval when the component unmounted
+
 ## 2020-01-12
 
 ### rax-portal [1.0.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2020-01-12
+
+### rax-portal [1.0.1]
+- Fix: not re-render when the container changes
+
 ## 2020-12-18
 
 ### rax-image [2.2.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2020-01-13
 
+### rax-text [2.0.5]
+
+#### Changed
+
+- Use text component in WeChat MiniProgram
+
 ### rax-countdown [1.1.5]
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 ### rax-portal [1.0.1]
 - Fix: not re-render when the container changes
 
+## 2020-12-29
+
+### rax-embed [1.1.2]
+
+#### Added
+- Support passing `id` prop to web-view component in miniapp
+
 ## 2020-12-18
 
 ### rax-image [2.2.4]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",

--- a/packages/rax-canvas/package.json
+++ b/packages/rax-canvas/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-canvas",
   "author": "rax",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Canvas for Rax.",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "miniprogram": ".",
   "miniappConfig": {
     "main": "lib/miniapp/index",
     "main:wechat": "lib/wechat-miniprogram/index",

--- a/packages/rax-countdown/package.json
+++ b/packages/rax-countdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-countdown",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Countdown component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-countdown/src/miniapp/index.ts
+++ b/packages/rax-countdown/src/miniapp/index.ts
@@ -25,6 +25,9 @@ Component({
       this.funcToExecute();
     }, this.props.interval);
   },
+  didUnmount: function didUnmount() {
+    if (this.counter) clearInterval(this.counter);
+  },
   methods: {
     msToTime() {
       const { count } = this.data;

--- a/packages/rax-embed/package.json
+++ b/packages/rax-embed/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-embed",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Embed container for Rax.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",

--- a/packages/rax-embed/src/bytedance-microapp/index.ts
+++ b/packages/rax-embed/src/bytedance-microapp/index.ts
@@ -35,6 +35,10 @@ Component({
     urlParam: {
       type: String,
       optionalTypes: [Object]
+    },
+    id: {
+      type: String,
+      value: ''
     }
   },
   attached() {

--- a/packages/rax-embed/src/bytedance-microapp/index.ttml
+++ b/packages/rax-embed/src/bytedance-microapp/index.ttml
@@ -1,3 +1,3 @@
 <sjs src="./tools.sjs" module="tools" />
-<web-view src="{{tools.genFixedUrl(src, urlParam)}}" onMessage="onMessage">
+<web-view src="{{tools.genFixedUrl(src, urlParam)}}" onMessage="onMessage" id="{{id}}">
 </web-view>

--- a/packages/rax-embed/src/index.tsx
+++ b/packages/rax-embed/src/index.tsx
@@ -52,6 +52,7 @@ const Embed = (props: Props) => {
   if (isMiniApp || isWeChatMiniProgram) {
     return (
       <web-view
+        id={props.id || ''}
         src={url}
         onMessage={props.onMessage}
       >

--- a/packages/rax-embed/src/miniapp/index.axml
+++ b/packages/rax-embed/src/miniapp/index.axml
@@ -1,3 +1,3 @@
 <import-sjs name="genFixedUrl" from="./genFixedUrl.sjs"/>
-<web-view src="{{genFixedUrl(src, urlParam)}}" onMessage="onMessage">
+<web-view src="{{genFixedUrl(src, urlParam)}}" onMessage="onMessage" id="{{id}}">
 </web-view>

--- a/packages/rax-embed/src/miniapp/index.ts
+++ b/packages/rax-embed/src/miniapp/index.ts
@@ -3,6 +3,7 @@ Component({
     url: '',
   },
   props: {
+    id: '',
     src: '',
     urlParam: '',
   },

--- a/packages/rax-embed/src/types.ts
+++ b/packages/rax-embed/src/types.ts
@@ -11,4 +11,5 @@ export interface Props extends Rax.Attributes {
   onMessage?: Function;
   useIframeInWeb?: boolean;
   style?: Rax.CSSProperties;
+  id?: string;
 }

--- a/packages/rax-embed/src/wechat-miniprogram/index.ts
+++ b/packages/rax-embed/src/wechat-miniprogram/index.ts
@@ -10,6 +10,10 @@ Component({
     urlParam: {
       type: String,
       optionalTypes: [Object]
+    },
+    id: {
+      type: String,
+      value: ''
     }
   },
   methods: {

--- a/packages/rax-embed/src/wechat-miniprogram/index.wxml
+++ b/packages/rax-embed/src/wechat-miniprogram/index.wxml
@@ -1,3 +1,3 @@
 <wxs src="./tools.wxs" module="tools" />
-<web-view src="{{tools.genFixedUrl(src, urlParam)}}" onMessage="onMessage">
+<web-view src="{{tools.genFixedUrl(src, urlParam)}}" onMessage="onMessage" id="{{id}}">
 </web-view>

--- a/packages/rax-icon/package.json
+++ b/packages/rax-icon/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-icon",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "icon component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "miniappConfig": {
     "main:quickapp": "lib/quickapp/index",
     "main": "lib/miniapp/index",

--- a/packages/rax-image/package.json
+++ b/packages/rax-image/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-image",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Image component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./lib ./package-lock.json ./demo/miniapp/lib ",

--- a/packages/rax-link/package.json
+++ b/packages/rax-link/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-link",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Link component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "rax-modal",
   "main": "lib/index.js",
   "quickappConfig": {

--- a/packages/rax-modal/src/types.ts
+++ b/packages/rax-modal/src/types.ts
@@ -3,6 +3,7 @@ import { RefAttributes, HTMLAttributes, CSSProperties, RaxElement, MutableRefObj
 export interface ModalProps extends RefAttributes<HTMLDivElement>, HTMLAttributes<HTMLDivElement> {
   visible: boolean;
   children?: RaxElement;
+  onMaskClick?: () => void;
   maskCanBeClick?: boolean;
   maskStyle?: CSSProperties;
   contentStyle?: CSSProperties;

--- a/packages/rax-portal/demo/index.jsx
+++ b/packages/rax-portal/demo/index.jsx
@@ -1,18 +1,57 @@
 import DriverUniversal from "driver-universal";
-import { createElement, render, Fragment } from "rax";
+import { createElement, render, Fragment, useEffect, useState } from "rax";
 import View from "rax-view";
 import Text from "rax-text";
 import Portal from "../src/index";
 
+const basicStyle = {
+  display: "block",
+  height: "200rpx",
+  margin: "10rpx",
+};
+
+let container1 = null;
+let container2 = null;
+
 const Demo = (props) => {
+  const [container, setContainer] = useState(null);
+
+  useEffect(() => {
+    container1 = document.getElementById("container-1");
+    container2 = document.getElementById("container-2");
+    setContainer(container1);
+  }, []);
+
+  const handleChange = () => {
+    if (container === container1) {
+      setContainer(container2);
+    } else {
+      setContainer(container1);
+    }
+  };
+
   return (
     <Fragment>
-      <View>
+      <View style={{ ...basicStyle, backgroundColor: "#eee" }}>
         <Text>Demo content</Text>
+        <Portal>
+          <View>
+            <Text>Body portal content</Text>
+          </View>
+        </Portal>
       </View>
-      <Portal>
+      <View
+        id="container-1"
+        style={{ ...basicStyle, backgroundColor: "#FFF7F0" }}
+      ></View>
+      <View
+        id="container-2"
+        style={{ ...basicStyle, backgroundColor: "#F0F7FF" }}
+      ></View>
+      <Portal container={container}>
         <View>
           <Text>Portal content</Text>
+          <Text onClick={handleChange}>Click me to change container</Text>
         </View>
       </Portal>
     </Fragment>

--- a/packages/rax-portal/package.json
+++ b/packages/rax-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-portal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "rax-portal",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rax-portal/src/index.tsx
+++ b/packages/rax-portal/src/index.tsx
@@ -10,6 +10,11 @@ const Portal: FunctionComponent<PortalProps> = (props) => {
   const el = useRef(document.createElement("div"));
 
   useEffect(() => {
+    // no container, skip render
+    if (!container) {
+      return undefined;
+    }
+
     if (isWeChatMiniProgram) {
       setTimeout(() => container.appendChild(el.current));
     } else {
@@ -19,7 +24,7 @@ const Portal: FunctionComponent<PortalProps> = (props) => {
     return () => {
       container.removeChild(el.current);
     };
-  }, []);
+  }, [container]);
 
   return createPortal(children, el.current);
 };

--- a/packages/rax-qrcode/package.json
+++ b/packages/rax-qrcode/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-qrcode",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "QRCode component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-scrollview",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "quickappConfig": {
     "main": "lib/quickapp/index"
   },

--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -5,6 +5,7 @@
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "miniappConfig": {
     "main": "lib/miniapp/index",
     "main:wechat": "lib/wechat-miniprogram/index",

--- a/packages/rax-text/package.json
+++ b/packages/rax-text/package.json
@@ -1,10 +1,11 @@
 {
   "name": "rax-text",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Text component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build",

--- a/packages/rax-text/src/index.tsx
+++ b/packages/rax-text/src/index.tsx
@@ -1,5 +1,5 @@
 import { createElement, forwardRef, ForwardRefExoticComponent } from 'rax';
-import { isWeex, isMiniApp } from 'universal-env';
+import { isWeex, isMiniApp, isWeChatMiniProgram } from 'universal-env';
 import { TextProps } from './types';
 import './index.css';
 
@@ -36,7 +36,7 @@ const Text: ForwardRefExoticComponent<TextProps> = forwardRef((props, ref) => {
         {textString}
       </text>
     );
-  } else if (isMiniApp) {
+  } else if (isMiniApp || isWeChatMiniProgram) {
     return (
       <text
         {...rest}

--- a/packages/rax-textinput/package.json
+++ b/packages/rax-textinput/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-textinput",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "TextInput component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "quickappConfig": {
     "main": "lib/quickapp/index"
   },

--- a/packages/rax-textinput/src/types.ts
+++ b/packages/rax-textinput/src/types.ts
@@ -131,6 +131,48 @@ export interface TextInputProps
   defaultValue?: string;
 
   /**
+   * Is it fully controlled
+   * (是否完全受控)
+   */
+  controlled?: boolean;
+
+  /**
+   * Placeholder color
+   * (占位文字颜色)
+   */
+  placeholderColor?: string;
+
+  /**
+   * Set the text of the button at the bottom right corner of the keyboard (miniapp)
+   * (设置键盘右下角按钮的文字,[小程序])
+   */
+  confirmType?: any;
+
+  /**
+   * When type is number, digit, idcard, whether the numeric keyboard is arranged randomly (miniapp)
+   * (当 type 为 number, digit, idcard 数字键盘是否随机排列,[小程序])
+   */
+  randomNumber?: boolean;
+
+  /**
+   * Whether to display word count (miniapp)
+   * (是否显示字数统计,[小程序])
+   */
+  showCount?: boolean;
+
+  /**
+   * The starting position of the focus cursor corresponding to the selected text (miniapp)
+   * (选中文本对应的焦点光标起始位置,[小程序])
+   */
+  selectionStart?: number;
+
+  /**
+   * The end position of the focus cursor corresponding to the selected text (miniapp)
+   * (选中文本对应的焦点光标结束位置,[小程序])
+   */
+  selectionEnd?: number;
+
+  /**
    * this function is called when the text box is out of focus. onBlur={() => console.log('lost focus')}
    * (文本框失焦时调用此函数。onBlur={() => console.log('失焦啦')})
    * @param {EventObject} event
@@ -150,6 +192,7 @@ export interface TextInputProps
    * @param {EventObject} event
    */
   onChange?: (event: EventObject) => void;
+  onChangeText?: (text: string) => void;
 
   /**
    * 文本框输入内容时调用此函数

--- a/packages/rax-video/package.json
+++ b/packages/rax-video/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rax-video",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Video component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "miniprogram": ".",
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./package-lock.json && rm -f ./yarn.lock && rm -rf demo/miniapp/lib",
     "build": "npm run clean && ../../node_modules/.bin/build-scripts build --config ../../build.json",


### PR DESCRIPTION
- [x] rax-protal 修复 container 变化后不会重复渲染的问题
- [x] rax-image 等基础组件更新支持微信小程序构建 npm 使用
- [x] rax-modal 增加 onMaskClick type 说明 
- [x] rax-textinput 增加 types 说明
- [x] rax-embed 支持配置 id
- [x] rax-text 微信小程序运行时使用 text 内置组件
- [x] rax-countdown 修复组件销毁后定时器未销毁的问题 