### PR TITLE
fix: missing deps on onChange

### DIFF
--- a/packages/rax-slider/CHANGELOG.md
+++ b/packages/rax-slider/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.5
+- [fix] missing dependency on Slider's `handleChange` function
+
 ## 3.0.4
 - [chore] Rename wechat native code to miniapp-wechat
 

--- a/packages/rax-slider/package.json
+++ b/packages/rax-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-slider",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Slider component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-slider/src/slider.miniapp.tsx
+++ b/packages/rax-slider/src/slider.miniapp.tsx
@@ -38,7 +38,7 @@ const Slider: ForwardRefExoticComponent<SliderProps> = forwardRef(
       setIndex(currentIndex);
       result.index = currentIndex;
       onChange && onChange(result);
-    }, [props.index]);
+    }, [props.index, onChange]);
 
     return (
       <swiper

--- a/packages/rax-slider/src/slider.weex.tsx
+++ b/packages/rax-slider/src/slider.weex.tsx
@@ -40,7 +40,7 @@ const Slider: ForwardRefExoticComponent<SliderProps> = forwardRef(
       }
       setIndex(currentIndex);
       onChange && onChange(result);
-    }, [props.index]);
+    }, [props.index, onChange]);
 
     return (
       <slider


### PR DESCRIPTION
prop `onChange` is missing in deps of Slider's `handleChange` function, which causes rax-slider to call the old version of `onChange`.