### PR TITLE
修复组件预览失败问题

### DIFF
--- a/packages/rax-barcode/demo/index.md
+++ b/packages/rax-barcode/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import { createElement, render, Component } from 'rax';
 import DU from 'driver-universal';
 import View from 'rax-view';
@@ -22,3 +31,4 @@ class App extends Component {
 }
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-canvas/demo/index.md
+++ b/packages/rax-canvas/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import { createElement, Component, render, createRef } from 'rax';
 import Canvas from 'rax-canvas';
 import DriverUniversal from 'driver-universal';
@@ -21,3 +30,4 @@ class CanvasSample extends Component {
 }
 
 render(<CanvasSample />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-countdown/demo/index.md
+++ b/packages/rax-countdown/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import { createElement, render, Component } from 'rax';
 import View from 'rax-view';
 import Countdown from '../src/index';
@@ -99,3 +108,4 @@ let styles = {
 };
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-gesture-view/demo/index.md
+++ b/packages/rax-gesture-view/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx createElement */
 import { createElement, Component, render } from 'rax';
@@ -28,3 +37,4 @@ class App extends Component {
 }
 
 render(<App />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-icon/demo/index.md
+++ b/packages/rax-icon/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, render, Component } from 'rax';
 import DU from 'driver-universal';
@@ -28,3 +37,4 @@ class Demo extends Component {
 }
 
 render(<Demo />, document.body, { driver: DU });
+```

--- a/packages/rax-image/demo/index.md
+++ b/packages/rax-image/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, render, useRef, Fragment } from 'rax';
 import DU from 'driver-universal';
@@ -28,3 +37,4 @@ const App = () => {
 };
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-link/demo/index.md
+++ b/packages/rax-link/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import {createElement, render} from 'rax';
 import DU from 'driver-universal';
 import Link from '../src/index';
@@ -7,3 +16,4 @@ render(<Link href={"//www.taobao.com"} onPress={(e)=>{console.log(e)}}><Text sty
   fontSize: 14,
   color: '#333333'
 }}>click to jump</Text></Link>, document.body, { driver: DU });
+```

--- a/packages/rax-modal/demo/index.md
+++ b/packages/rax-modal/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, render, useState, useEffect } from 'rax';
 import DriverUniversal from 'driver-universal';
@@ -45,3 +54,4 @@ const Demo = props => {
 };
 
 render(<Demo />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-parallax/demo/index.md
+++ b/packages/rax-parallax/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, Component, render, createRef } from 'rax';
 import View from 'rax-view';
@@ -178,3 +187,4 @@ const styles = {
 };
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-portal/demo/index.md
+++ b/packages/rax-portal/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import DriverUniversal from "driver-universal";
 import { createElement, render, Fragment, useEffect, useState } from "rax";
 import View from "rax-view";
@@ -59,3 +68,4 @@ const Demo = (props) => {
 };
 
 render(<Demo />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-qrcode/demo/index.md
+++ b/packages/rax-qrcode/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, render } from 'rax';
 import DriverUniversal from 'driver-universal';
@@ -13,3 +22,4 @@ function App() {
 }
 
 render(<App />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-recyclerview/demo/index.md
+++ b/packages/rax-recyclerview/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import {createElement, Component, render} from 'rax';
 import DriverUniversal from 'driver-universal';
 import View from 'rax-view';
@@ -155,3 +164,4 @@ let styles = {
 };
 
 render(<App />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-scrollview/demo/index.md
+++ b/packages/rax-scrollview/demo/index.md
@@ -1,3 +1,11 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
 /* eslint-disable import/no-extraneous-dependencies */
 /**
  * @jsx createElement
@@ -84,3 +92,4 @@ function App() {
 }
 
 render(<App />, document.body, { driver: DriverUniversal });
+```

--- a/packages/rax-slider/demo/index.md
+++ b/packages/rax-slider/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, Component, render, createRef } from 'rax';
 import View from 'rax-view';
@@ -85,3 +94,4 @@ class App extends Component {
 }
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-textinput/demo/index.md
+++ b/packages/rax-textinput/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, Component, render, createRef } from 'rax';
 import DU from 'driver-universal';
@@ -187,3 +196,4 @@ class App extends Component {
 }
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-video/demo/index.md
+++ b/packages/rax-video/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, render, useState } from 'rax';
 import Video from '../src/index';
@@ -35,3 +44,4 @@ const App = () => {
 };
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-view/demo/index.md
+++ b/packages/rax-view/demo/index.md
@@ -1,3 +1,12 @@
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { createElement, useRef, useEffect, render } from 'rax';
 import DU from 'driver-universal';
@@ -52,3 +61,4 @@ const App = () => {
 };
 
 render(<App />, document.body, { driver: DU });
+```

--- a/packages/rax-waterfall/demo/index.md
+++ b/packages/rax-waterfall/demo/index.md
@@ -1,4 +1,13 @@
 
+---
+title: Baisc
+order: 1
+---
+
+basic usage
+
+```jsx
+
 import {createElement, Component, render, createRef} from 'rax';
 import View from 'rax-view';
 import Text from 'rax-text';
@@ -107,3 +116,4 @@ class App extends Component {
 }
 
 render(<App />, document.body, { driver: DU });
+```


### PR DESCRIPTION
修复外层 build-scripts 升级大版本（仅支持预览 md 文件） 导致 demo/xxx.jsx 无法预览问题。
1. 仅修改 demo/index.jsx 保证组件可预览；
2. build-scripts 层需支持预览 jsx 文件。