### PR TITLE
fix: up deps of rax-modal

### DIFF
--- a/packages/rax-modal/CHANGELOG.md
+++ b/packages/rax-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.0
+
+- update dependencies:
+  - rax-text: v1.x to v2.x
+  - rax-view: v1.x to v2.x
+  
 ## v1.5.6
 
 - add onMaskClick types

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-modal",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "description": "rax-modal",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-modal/package.json
+++ b/packages/rax-modal/package.json
@@ -35,8 +35,8 @@
     "react-component"
   ],
   "dependencies": {
-    "rax-text": "^1.1.0",
-    "rax-view": "^1.1.0",
+    "rax-text": "^2.0.0",
+    "rax-view": "^2.0.0",
     "universal-env": "^3.0.0",
     "universal-transition": "^1.0.0"
   },


### PR DESCRIPTION
rax-modal 依赖的 rax-text 和 rax-view 升级到 2.x

https://github.com/raxjs/rax-components/issues/365