### PR TITLE
fix: pixelRatio没有初始化导致endReachedThreshold为NaN

### DIFF
--- a/packages/rax-scrollview/CHANGELOG.md
+++ b/packages/rax-scrollview/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 3.6.1
+- Fix `pixelRatio` is not initialized and make onEndReached can not triggered
 ## 3.6.0
 
 - Support `string` type in runtime miniapp and web, of onEndReachedThreshold, scrollTo

--- a/packages/rax-scrollview/CHANGELOG.md
+++ b/packages/rax-scrollview/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.6.1
 - Fix `pixelRatio` is not initialized and make onEndReached can not triggered
+
 ## 3.6.0
 
 - Support `string` type in runtime miniapp and web, of onEndReachedThreshold, scrollTo

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-scrollview",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -69,12 +69,12 @@ function getPixelRatio() {
 }
 
 function translateToPx(origin: string | number): number {
+  const pixelRatio = getPixelRatio();
   if (typeof origin === 'number') {
     return origin * pixelRatio;
   }
   const matched = /^(\d+)(r{0,1}px){0,1}$/.exec(origin);
   if (matched) {
-    const pixelRatio = getPixelRatio();
     if (!matched[2]) {
       return parseInt(matched[1]) * pixelRatio;
     }


### PR DESCRIPTION
如果onEndReachedThreshold值为number的时候，endReachedThreshold为NaN，最终导致onEndReached不会触发的问题