### PR TITLE
fix(rax-swiper): stop bubble in runtime miniapp

### DIFF
--- a/packages/rax-swiper/CHANGELOG.md
+++ b/packages/rax-swiper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.11
+
+- [fix] stop `change` event bubble in runtime miniapp
+
 ## 0.1.10
 
 - [fix] calc error in css file caused by `postcss-calc`

--- a/packages/rax-swiper/package.json
+++ b/packages/rax-swiper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rax-swiper",
   "author": "rax",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Swiper component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-swiper/src/miniapp-runtime/swiper.tsx
+++ b/packages/rax-swiper/src/miniapp-runtime/swiper.tsx
@@ -1,4 +1,4 @@
-import { createElement, useState, forwardRef, useImperativeHandle, useMemo } from 'rax';
+import { createElement, useState, forwardRef, useImperativeHandle, useMemo, useRef } from 'rax';
 import Children from 'rax-children';
 
 import { SwiperType } from '../types';
@@ -24,11 +24,16 @@ const Swiper: SwiperType = forwardRef((props, ref) => {
     ...rest
   } = props;
 
+  const swiperRef = useRef();
   const [ activeIndex, setActiveIndex ] = useState(initialSlide);
   const size = useMemo(() => Children.count(children), [children]);
   const className = useMemo(() => outerClassName ? `${innerClassName} ${outerClassName}` : innerClassName, [outerClassName]);
 
   const slideChange = (event) => {
+    if (swiperRef.current !== event.target) {
+      // stop bubble
+      return;
+    }
     if (onSlideChange) {
       onSlideChange({
         activeIndex: event.detail.current,
@@ -78,6 +83,7 @@ const Swiper: SwiperType = forwardRef((props, ref) => {
 
   return (
     <swiper
+      ref={swiperRef}
       indicator-dots={_pagination}
       autoplay={_autoplay}
       current={activeIndex}


### PR DESCRIPTION
在运行时小程序中，swiper 的 onChange 回调 是通过 `change` 事件触发的。

本 pr 修复了在 swiper 内其他节点触发 `change` 事件时影响 activeIndex 的情况。