### PR TITLE
feat: Weex 2.0 support scrollTo and scrollIntoView in scrollview and recyclerview

### DIFF
--- a/packages/rax-recyclerview/CHANGELOG.md
+++ b/packages/rax-recyclerview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+- Support weex v2 scrollTo and scrollIntoView
+
 ## 1.3.6
 
 - Fix RecyclerView error: "Uncaught TypeError: Cannot add property style, object is not extensible", when use virtual list mode.

--- a/packages/rax-recyclerview/README.md
+++ b/packages/rax-recyclerview/README.md
@@ -43,6 +43,20 @@ npm install rax-recyclerview --save
 | x        | `number` | -          | ✘        | 横向的偏移量 |
 | y        | `number` | -          | ✘        | 纵向的偏移量 |
 
+### scrollIntoView({id: string, animated?: boolean, duration?: number})
+
+支持 Weex 2.0 和未指定 itemSize 时的 Web 场景。
+
+#### 参数
+
+**参数为 `object`，包含以下属性**
+
+| **属性** | **类型**  | **默认值** | **必填** | **描述** |
+| -------- | --------- | ---------- | -------- | -------- |
+| id       | `string`  | -          | 是       | 需要滚动到的元素 `id` |
+| animated | `boolean` | `true`     | 否       | 在设置滚动条位置时使用动画过渡 |
+| duration | `number`  | 400        | 否       | 当 `animated` 设置为 `true` 时，可以设置 duration 来控制动画的执行时间，单位 `ms` |
+
 ### 示例
 
 ```jsx

--- a/packages/rax-recyclerview/package.json
+++ b/packages/rax-recyclerview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-recyclerview",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "RecyclerView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-recyclerview/src/index.js
+++ b/packages/rax-recyclerview/src/index.js
@@ -16,6 +16,8 @@ import ScrollView from 'rax-scrollview';
 import Children from 'rax-children';
 import VirtualizedList from './VirtualizedList/index';
 
+const isWeexV2 = typeof __weex_v2__ === 'object';
+
 const Context = createContext(true);
 
 const Cell = memo(
@@ -99,16 +101,30 @@ const RecyclerView = forwardRef((props, ref) => {
           : true;
 
       if (isWeex) {
-        let dom = __weex_require__('@weex-module/dom');
-        let firstNode = findDOMNode(firstNodePlaceholder.current);
-        dom.scrollToElement(firstNode, {
-          offset: x || y || 0,
-          animated
-        });
+        if (isWeexV2) {
+          list.current.scrollTo(undefined, options);
+        } else {
+          let dom = __weex_require__('@weex-module/dom');
+          let firstNode = findDOMNode(firstNodePlaceholder.current);
+          dom.scrollToElement(firstNode, {
+            offset: x || y || 0,
+            animated
+          });
+        }
       } else if (needRecycler) {
         scrollview.current.scrollTo(x || y, animated);
       } else {
         scrollview.current.scrollTo(options);
+      }
+    },
+    scrollIntoView(options) {
+      if (isWeex && isWeexV2) {
+        const { id, animated = true, duration } = options || {};
+        if (!id) {
+          throw new Error('Params missing id.');
+        }
+        const node = document.getElementById(id);
+        list.current.scrollTo(node, {animated, duration});
       }
     }
   }));

--- a/packages/rax-recyclerview/src/index.js
+++ b/packages/rax-recyclerview/src/index.js
@@ -118,13 +118,17 @@ const RecyclerView = forwardRef((props, ref) => {
       }
     },
     scrollIntoView(options) {
-      if (isWeex && isWeexV2) {
-        const { id, animated = true, duration } = options || {};
-        if (!id) {
-          throw new Error('Params missing id.');
+      if (isWeex) {
+        if (isWeexV2) {
+          const { id, animated = true, duration } = options || {};
+          if (!id) {
+            throw new Error('Params missing id.');
+          }
+          const node = document.getElementById(id);
+          list.current.scrollTo(node, { animated, duration });
         }
-        const node = document.getElementById(id);
-        list.current.scrollTo(node, {animated, duration});
+      } else if (!needRecycler) {
+        scrollview.current.scrollIntoView(options);
       }
     }
   }));

--- a/packages/rax-scrollview/CHANGELOG.md
+++ b/packages/rax-scrollview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.2
+
+- Fix weex v2 scrollTo and scrollIntoView
+
 ## 3.7.1
 
 - Fix: can't pass float number to scrollTo

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-scrollview",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-scrollview/src/weex/index.tsx
+++ b/packages/rax-scrollview/src/weex/index.tsx
@@ -21,10 +21,6 @@ const isWeexV2 = typeof __weex_v2__ === 'object';
 
 const baseCls = 'rax-scrollview';
 
-function scrollTo(scrollerRef, ...args) {
-  scrollerRef.current.scrollTo(...args);
-}
-
 const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
   (props, ref) => {
     let {
@@ -69,11 +65,10 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
         animated?: boolean;
         duration?: number;
       }) {
-        const { x = 0, y = 0, animated = true, duration } = options || {};
-
         if (isWeexV2) {
-          scrollTo(scrollerRef, x, y, animated, duration);
+          (scrollerRef.current as any).scrollTo(undefined, options);
         } else {
+          const { x = 0, y = 0, animated = true } = options || {};
           const dom = __weex_require__('@weex-module/dom');
           const contentContainer = contentContainerRef.current;
           /**
@@ -99,7 +94,7 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
         const node = getElementById(id);
         if (node) {
           if (isWeexV2) {
-            scrollTo(scrollerRef, node, animated, duration);
+            (scrollerRef.current as any).scrollTo(node, { animated, duration });
           } else {
             const dom = __weex_require__('@weex-module/dom');
             dom.scrollToElement(node, {
@@ -129,31 +124,31 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
       }
     }
 
-    let refreshContainer: any = <View />;
-    let contentChild: Rax.RaxNode = null;
-    if (Array.isArray(children)) {
-      contentChild = children.map(child => {
-        if (
-          typeof child === 'object' &&
-          child !== null &&
-          'type' in child &&
-          child.type == RefreshControl
-        ) {
-          refreshContainer = child;
-          return null;
-        } else {
-          return child;
-        }
-      });
-    } else {
-      contentChild = children;
-    }
-
+    let refreshContainer: any = null;
     let contentContainer;
     if (isWeexV2) {
-      refreshContainer = null;
-      contentContainer = children;
+      contentContainer =  children;
     } else {
+      refreshContainer = <View />;
+      let contentChild: Rax.RaxNode = null;
+      if (Array.isArray(children)) {
+        contentChild = children.map(child => {
+          if (
+            typeof child === 'object' &&
+            child !== null &&
+            'type' in child &&
+            child.type == RefreshControl
+          ) {
+            refreshContainer = child;
+            return null;
+          } else {
+            return child;
+          }
+        });
+      } else {
+        contentChild = children;
+      }
+
       contentContainer = (
         <View
           ref={contentContainerRef}

--- a/packages/rax-scrollview/src/weex/index.tsx
+++ b/packages/rax-scrollview/src/weex/index.tsx
@@ -127,7 +127,7 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
     let refreshContainer: any = null;
     let contentContainer;
     if (isWeexV2) {
-      contentContainer =  children;
+      contentContainer = children;
     } else {
       refreshContainer = <View />;
       let contentChild: Rax.RaxNode = null;


### PR DESCRIPTION
- fix scrollTo and scrollIntoView method in scroller for Weex 2.0
- add scrollTo and scrollIntoView method in recyclerview for Weex 2.0
- add scrollIntoView in recyclerview for Web when needRecycler is false