### PR TITLE
revert: revert maxlength for compat set maxlength to empty string.

### DIFF
--- a/packages/rax-textinput/CHANGELOG.md
+++ b/packages/rax-textinput/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.6
+
+- revert maxlength for compat set maxlength to empty string.
+
 ## 1.4.5
 
 - maxlength and random-Number is invalid property in dom.

--- a/packages/rax-textinput/package.json
+++ b/packages/rax-textinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-textinput",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "TextInput component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-textinput/src/index.tsx
+++ b/packages/rax-textinput/src/index.tsx
@@ -139,7 +139,7 @@ const TextInput: ForwardRefExoticComponent<TextInputProps> = forwardRef(
       ...props,
       'aria-label': accessibilityLabel,
       autoComplete: autoComplete && 'on',
-      maxLength: maxlength || maxLength,
+      maxlength: maxlength || maxLength,
       onChange: (onChange || onChangeText) && handleChange,
       onBlur: onBlur && handleBlur,
       onFocus: onFocus && handleFocus


### PR DESCRIPTION
close #459 

这次的版本修改是这个 https://github.com/raxjs/rax-components/pull/457 ，为了兼容 React 运行时白名单校验 props 的问题，里面把 maxlength 改成了 maxLength，否则在 React runtime 中会抛出错误。
原因是，maxlength 在 web 标准或者说在 input 的props 中不存在，所以走的是兜底 attributes 的逻辑，而 maxLength 走的是 input element 的 props 的逻辑。按照标准，应该走 maxLength 更合适，包括 React 中也会有白名单校验。但是业务中用法是当 schema 中不存在 maxlength 时，会设置一个空字符串""到 maxlength 中。原本组件 maxlength 设置空字符串，走了 attributes 逻辑没有问题，设置无效，但是当走了 props 时，在 web 引擎中会做校验，把 '' 变成 0，所以导致了无法输入。

讨论： 未来需要把 rax 体系支持在 React 上运行的同事，为了保证成本以及降低目前已使用 Rax 体系用户的影响，后续考虑把这些 compat 逻辑统一放到 rax-compat 中，以兼容 Rax 体系在 React runtime 上的正确运行。