### PR TITLE
fix: disable scroll not working

### DIFF
--- a/packages/rax-scrollview/CHANGELOG.md
+++ b/packages/rax-scrollview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.5
+
+- Fix change disableScroll from `true` to `false` is not working.
+
 ## 3.7.4
 
 - Fix when scrollerNode is null

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-scrollview",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -257,11 +257,9 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
 
       scrollerStyle.WebkitOverflowScrolling = 'touch';
       if (horizontal) {
-        scrollerStyle.overflowX = 'scroll';
-        scrollerStyle.overflowY = 'hidden';
+        scrollerStyle.overflow = 'scroll hidden';
       } else {
-        scrollerStyle.overflowX = 'hidden';
-        scrollerStyle.overflowY = 'scroll';
+        scrollerStyle.overflow = 'hidden scroll';
       }
 
       if (disableScroll) {


### PR DESCRIPTION
当 disbaleScroll 初始值为 false 时，再次设置为 true，不会生效，ScrollView 依然不能滚动。原因是 overflow 属性虽然被 delete 了，但没有被重新赋值。