### PR TITLE
Fix/touch in virtualized list

### DIFF
--- a/packages/rax-recyclerview/CHANGELOG.md
+++ b/packages/rax-recyclerview/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.2
 
 - VirtualizedList should support touch event.
+- Exception to render when BaseList has only one child node.
 
 ## 1.4.1
 

--- a/packages/rax-recyclerview/CHANGELOG.md
+++ b/packages/rax-recyclerview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.2
+
+- VirtualizedList should support touch event.
+
 ## 1.4.1
 
 - Add offsetX and offsetY to scrollIntoView of weex v2

--- a/packages/rax-recyclerview/package.json
+++ b/packages/rax-recyclerview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-recyclerview",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "RecyclerView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-recyclerview/src/VirtualizedList/BaseList.js
+++ b/packages/rax-recyclerview/src/VirtualizedList/BaseList.js
@@ -276,9 +276,9 @@ export default class BaseList extends PureComponent {
     /**
      * solve children is not an array.
      */
-    if (typeof start !== 'undefined' && typeof stop !== 'undefined' && children.slice) {
+    if (typeof start !== 'undefined' && typeof stop !== 'undefined' && children) {
       let index = start;
-      renderChildren = children.slice(start, stop + 1);
+      renderChildren = Array.isArray(children) ? children.slice(start, stop + 1) : [ children ];
       renderChildren.forEach((child) => {
         /**
          * child.props.style = newStyle cause: Uncaught TypeError: Cannot add property style, object is not extensible

--- a/packages/rax-recyclerview/src/VirtualizedList/index.js
+++ b/packages/rax-recyclerview/src/VirtualizedList/index.js
@@ -110,6 +110,10 @@ export default class VirtualizedList extends BaseList {
       showsVerticalScrollIndicator,
       className,
       nestedList,
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+      onTouchCancel,
       ...props
     } = this.props;
     const { offset } = this.state;
@@ -138,7 +142,15 @@ export default class VirtualizedList extends BaseList {
     });
 
     return (
-      <div ref={this.getRef} style={wrapperStyle} className={className}>
+      <div
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        onTouchCancel={onTouchCancel}
+        ref={this.getRef}
+        style={wrapperStyle}
+        className={className}
+      >
         <div style={innerStyle}>{nodeItems}</div>
       </div>
     );


### PR DESCRIPTION
close #451

问题的原因是 touch 事件在 props 中向下传递最终没有传递到 DOM 上。

close #450

问题的原因是当单个 children 时，props 中的children 是一个 object 而不是 array，导致判断异常没有走进应有的逻辑而无法正常渲染。