### PR TITLE
feat: add scrollIntoView attribute in ScrollViewRefObject interface

### DIFF
--- a/packages/rax-scrollview/CHANGELOG.md
+++ b/packages/rax-scrollview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.6
+
+- Add `scrollIntoView` attribute in `ScrollViewRefObject` interface.
+
 ## 3.7.5
 
 - Fix change disableScroll from `true` to `false` is not working.

--- a/packages/rax-scrollview/package.json
+++ b/packages/rax-scrollview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-scrollview",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "ScrollView component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-scrollview/src/types.ts
+++ b/packages/rax-scrollview/src/types.ts
@@ -12,6 +12,16 @@ export interface ScrollViewRefObject {
     id?: string;
     animated?: boolean;
     duration?: number;
+    offsetX?: number;
+    offsetY?: number;
+  }) => void;
+}
+
+export interface MiniappScrollViewRefObject extends ScrollViewRefObject {
+  scrollIntoView: (options?: {
+    id?: string;
+    animated?: boolean;
+    duration?: number;
   }) => void;
 }
 

--- a/packages/rax-scrollview/src/types.ts
+++ b/packages/rax-scrollview/src/types.ts
@@ -8,6 +8,11 @@ export interface ScrollViewRefObject {
     y?: number | string;
     animated?: boolean;
   }) => void;
+  scrollIntoView: (options?: {
+    id?: string;
+    animated?: boolean;
+    duration?: number;
+  }) => void;
 }
 
 export interface ScrollEvent extends UIEvent<HTMLDivElement> {


### PR DESCRIPTION
ScrollViewRefObject 中没有 scrollIntoView，在useRef中传入泛型调用会提示没有对应api