### PR TITLE
feat: support webpack 4 and 5

### DIFF
--- a/packages/rax-swiper/CHANGELOG.md
+++ b/packages/rax-swiper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2
+
+- [feat] both support webpack 4 and webpack 5.
+
 ## 0.2.1
 
 - [fix] import css of swiper not found.

--- a/packages/rax-swiper/package.json
+++ b/packages/rax-swiper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rax-swiper",
   "author": "rax",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Swiper component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -60,7 +60,7 @@
     "rax-children": "^1.0.0",
     "rax-clone-element": "^1.0.0",
     "rax-view": "^2.0.0",
-    "swiper": "^8.2.4",
+    "swiper": "^8.4.5",
     "universal-env": "^3.2.0"
   },
   "peerDependencies": {

--- a/packages/rax-swiper/src/web/init-swiper.js
+++ b/packages/rax-swiper/src/web/init-swiper.js
@@ -2,7 +2,9 @@
 import { Swiper, Autoplay, Pagination } from 'swiper';
 import { needsNavigation, needsPagination, needsScrollbar } from './utils';
 
-import 'swiper/css/bundle';
+// swiper >= 8.4.4 added ./swiper-bundle.min.css in exports field,
+// both support webpack 4 and 5 resolving rule.
+import 'swiper/swiper-bundle.min.css';
 
 Swiper.use([Autoplay, Pagination]);
 function initSwiper(swiperParams) {


### PR DESCRIPTION
swiper >= 8.4.4 版本同时支持了 webpack 4 的路径 resolve 和 webpack 5 的 exports 字段 resolve, 所以跟进这个版本, 更新一个版本