### PR TITLE
Firefox + standards support for showsScrollIndicator=false

### DIFF
--- a/packages/rax-recyclerview/src/VirtualizedList/index.js
+++ b/packages/rax-recyclerview/src/VirtualizedList/index.js
@@ -121,11 +121,14 @@ export default class VirtualizedList extends BaseList {
 
     let showsScrollIndicator = horizontal ? showsHorizontalScrollIndicator : showsVerticalScrollIndicator;
 
-    if (!showsScrollIndicator && typeof document !== 'undefined' && !document.getElementById(STYLE_NODE_ID)) {
-      let styleNode = document.createElement('style');
-      styleNode.id = STYLE_NODE_ID;
-      document.head.appendChild(styleNode);
-      styleNode.innerHTML = `.${this.props.className}::-webkit-scrollbar{display: none;}`;
+    if (!showsScrollIndicator) {
+      wrapperStyle.scrollbarWidth = 'none';
+      if (typeof document !== 'undefined' && !document.getElementById(STYLE_NODE_ID)) {
+        let styleNode = document.createElement('style');
+        styleNode.id = STYLE_NODE_ID;
+        document.head.appendChild(styleNode);
+        styleNode.innerHTML = `.${this.props.className}::-webkit-scrollbar{display: none;}`;
+      }
     }
 
     // return children when has nested list

--- a/packages/rax-scrollview/src/web/index.tsx
+++ b/packages/rax-scrollview/src/web/index.tsx
@@ -244,16 +244,18 @@ const ScrollView: ForwardRefExoticComponent<ScrollViewProps> = forwardRef(
       ? showsHorizontalScrollIndicator
       : showsVerticalScrollIndicator;
     {
-      if (
-        !showsScrollIndicator &&
-        typeof document !== 'undefined' &&
-        typeof document.getElementById === 'function' &&
-        !document.getElementById(STYLE_NODE_ID)
-      ) {
-        let styleNode = document.createElement('style');
-        styleNode.id = STYLE_NODE_ID;
-        document.head.appendChild(styleNode);
-        styleNode.innerHTML = `.${baseCls}::-webkit-scrollbar{display: none;}`;
+      if (!showsScrollIndicator) {
+        scrollerStyle.scrollbarWidth = 'none';
+        if (
+          typeof document !== 'undefined' &&
+          typeof document.getElementById === 'function' &&
+          !document.getElementById(STYLE_NODE_ID)
+        ) {
+          let styleNode = document.createElement('style');
+          styleNode.id = STYLE_NODE_ID;
+          document.head.appendChild(styleNode);
+          styleNode.innerHTML = `.${baseCls}::-webkit-scrollbar{display: none;}`;
+        }
       }
 
       scrollerStyle.WebkitOverflowScrolling = 'touch';


### PR DESCRIPTION
I tracked https://bugzilla.mozilla.org/show_bug.cgi?id=1926506 to this.

Use `scrollbar-width: none` ([link](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width)) much like we use `::-webkit-scrollbar` on WebKit browsers.